### PR TITLE
add support for base and target arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ composer diff # Displays packages changed in current git tree compared with HEAD
 ## Advanced usage
 
 ```shell script
-composer diff -b master:composer.lock -t develop:composer.lock -p # Compare master and develop branches, including platform dependencies
+composer diff master # Compare current composer.lock with the one on master branch
+composer diff master:composer.lock develop:composer.lock -p # Compare master and develop branches, including platform dependencies
 composer diff --no-dev # ignore dev dependencies
 composer diff -p # include platform dependencies
 composer diff -f json # Output as JSON instead of table

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -9,6 +9,7 @@ use IonBazan\ComposerDiff\Formatter\MarkdownListFormatter;
 use IonBazan\ComposerDiff\Formatter\MarkdownTableFormatter;
 use IonBazan\ComposerDiff\PackageDiff;
 use IonBazan\ComposerDiff\Url\GeneratorContainer;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -43,6 +44,8 @@ class DiffCommand extends BaseCommand
     {
         $this->setName('diff')
             ->setDescription('Displays package diff')
+            ->addArgument('base', InputArgument::OPTIONAL, 'Base composer.lock file path or git ref')
+            ->addArgument('target', InputArgument::OPTIONAL, 'Target composer.lock file path or git ref')
             ->addOption('base', 'b', InputOption::VALUE_REQUIRED, 'Base composer.lock file path or git ref', 'HEAD:composer.lock')
             ->addOption('target', 't', InputOption::VALUE_REQUIRED, 'Target composer.lock file path or git ref', 'composer.lock')
             ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Ignore dev dependencies')
@@ -59,8 +62,8 @@ class DiffCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $base = $input->getOption('base');
-        $target = $input->getOption('target');
+        $base = $input->getArgument('base') !== null ? $input->getArgument('base') : $input->getOption('base');
+        $target = $input->getArgument('target') !== null ? $input->getArgument('target') :$input->getOption('target');
         $withPlatform = $input->getOption('with-platform');
         $withUrls = $input->getOption('with-links');
         $this->gitlabDomains = array_merge($this->gitlabDomains, $input->getOption('gitlab-domains'));

--- a/tests/Integration/DiffCommandTest.php
+++ b/tests/Integration/DiffCommandTest.php
@@ -87,6 +87,25 @@ OUTPUT
                     '--no-dev' => null,
                 ),
             ),
+            'no-dev with arguments' => array(
+                <<<OUTPUT
+| Prod Packages                      | Operation | Base    | Target  |
+|------------------------------------|-----------|---------|---------|
+| psr/event-dispatcher               | New       | -       | 1.0.0   |
+| symfony/deprecation-contracts      | New       | -       | v2.1.2  |
+| symfony/event-dispatcher           | Upgraded  | v2.8.52 | v5.1.2  |
+| symfony/event-dispatcher-contracts | New       | -       | v2.1.2  |
+| symfony/polyfill-php80             | New       | -       | v1.17.1 |
+
+
+OUTPUT
+            ,
+                array(
+                    'base' => __DIR__.'/../fixtures/base/composer.lock',
+                    'target' => __DIR__.'/../fixtures/target/composer.lock',
+                    '--no-dev' => null,
+                ),
+            ),
             'no-prod' => array(
                 <<<OUTPUT
 | Dev Packages                       | Operation  | Base  | Target |


### PR DESCRIPTION
This change allows to use command arguments instead of options to define base and target. 
You can now simply call `composer diff master` instead of `composer diff --base=master` 🚀 