### PR TITLE
fix parsing platform versions as they may contain the constraints there

### DIFF
--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -62,8 +62,8 @@ class DiffCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $base = $input->getArgument('base') !== null ? $input->getArgument('base') : $input->getOption('base');
-        $target = $input->getArgument('target') !== null ? $input->getArgument('target') :$input->getOption('target');
+        $base = null !== $input->getArgument('base') ? $input->getArgument('base') : $input->getOption('base');
+        $target = null !== $input->getArgument('target') ? $input->getArgument('target') : $input->getOption('target');
         $withPlatform = $input->getOption('with-platform');
         $withUrls = $input->getOption('with-links');
         $this->gitlabDomains = array_merge($this->gitlabDomains, $input->getOption('gitlab-domains'));

--- a/src/Formatter/AbstractFormatter.php
+++ b/src/Formatter/AbstractFormatter.php
@@ -11,6 +11,7 @@ use Composer\Semver\Semver;
 use Composer\Semver\VersionParser;
 use IonBazan\ComposerDiff\Url\GeneratorContainer;
 use Symfony\Component\Console\Output\OutputInterface;
+use UnexpectedValueException;
 
 abstract class AbstractFormatter implements Formatter
 {
@@ -80,9 +81,12 @@ abstract class AbstractFormatter implements Formatter
     protected static function isUpgrade(UpdateOperation $operation)
     {
         $versionParser = new VersionParser();
-        $normalizedFrom = $versionParser->normalize($operation->getInitialPackage()->getVersion());
-        $normalizedTo = $versionParser->normalize($operation->getTargetPackage()->getVersion());
-
+        try {
+            $normalizedFrom = $versionParser->normalize($operation->getInitialPackage()->getVersion());
+            $normalizedTo = $versionParser->normalize($operation->getTargetPackage()->getVersion());
+        } catch (UnexpectedValueException $e) {
+            return true; // Consider as upgrade if versions are not parsable
+        }
         $sorted = Semver::sort(array($normalizedTo, $normalizedFrom));
 
         return $sorted[0] === $normalizedFrom;

--- a/tests/Formatter/FormatterTest.php
+++ b/tests/Formatter/FormatterTest.php
@@ -47,6 +47,7 @@ abstract class FormatterTest extends TestCase
             new UpdateOperation($this->getPackage('a/package-2', '1.0.0'), $this->getPackage('a/package-2', '1.2.0')),
             new UpdateOperation($this->getPackage('a/package-3', '2.0.0'), $this->getPackage('a/package-3', '1.1.1')),
             new UpdateOperation($this->getPackage('a/no-link-2', '2.0.0'), $this->getPackage('a/no-link-2', '1.1.1')),
+            new UpdateOperation($this->getPackage('php', '>=7.4.6'), $this->getPackage('php', '^8.0')),
         );
         $devPackages = array(
             new UpdateOperation($this->getPackage('a/package-5', 'dev-master', 'dev-master 1234567'), $this->getPackage('a/package-5', '1.1.1')),
@@ -114,7 +115,7 @@ abstract class FormatterTest extends TestCase
             ->getMock();
         $generators->method('get')
             ->willReturnCallback(function (PackageInterface $package) use ($generator) {
-                if (false !== strpos($package->getName(), 'a/no-link')) {
+                if ('php' === $package->getName() || false !== strpos($package->getName(), 'a/no-link')) {
                     return null;
                 }
 

--- a/tests/Formatter/JsonFormatterTest.php
+++ b/tests/Formatter/JsonFormatterTest.php
@@ -121,6 +121,13 @@ class JsonFormatterTest extends FormatterTest
                                 'version_target' => '1.1.1',
                                 'compare' => null,
                             ),
+                        'php' => array(
+                            'name' => 'php',
+                            'operation' => 'upgrade',
+                            'version_base' => '>=7.4.6',
+                            'version_target' => '^8.0',
+                            'compare' => null,
+                        ),
                     ),
                 'packages-dev' => array(
                         'a/package-5' => array(
@@ -179,6 +186,12 @@ class JsonFormatterTest extends FormatterTest
                     'operation' => 'downgrade',
                     'version_base' => '2.0.0',
                     'version_target' => '1.1.1',
+                ),
+                'php' => array(
+                    'name' => 'php',
+                    'operation' => 'upgrade',
+                    'version_base' => '>=7.4.6',
+                    'version_target' => '^8.0',
                 ),
             ),
             'packages-dev' => array(

--- a/tests/Formatter/MarkdownListFormatterTest.php
+++ b/tests/Formatter/MarkdownListFormatterTest.php
@@ -20,6 +20,7 @@ Prod Packages
  - Upgrade a/package-2 (1.0.0 => 1.2.0) [Compare](https://example.com/c/1.0.0..1.2.0)
  - Downgrade a/package-3 (2.0.0 => 1.1.1) [Compare](https://example.com/c/2.0.0..1.1.1)
  - Downgrade a/no-link-2 (2.0.0 => 1.1.1) 
+ - Upgrade php (>=7.4.6 => ^8.0) 
 
 Dev Packages
 ============
@@ -41,6 +42,7 @@ Prod Packages
  - Upgrade a/package-2 (1.0.0 => 1.2.0)
  - Downgrade a/package-3 (2.0.0 => 1.1.1)
  - Downgrade a/no-link-2 (2.0.0 => 1.1.1)
+ - Upgrade php (>=7.4.6 => ^8.0)
 
 Dev Packages
 ============

--- a/tests/Formatter/MarkdownTableFormatterTest.php
+++ b/tests/Formatter/MarkdownTableFormatterTest.php
@@ -12,13 +12,14 @@ class MarkdownTableFormatterTest extends FormatterTest
     {
         if ($withUrls) {
             return <<<OUTPUT
-| Prod Packages | Operation  | Base  | Target | Link                                          |
-|---------------|------------|-------|--------|-----------------------------------------------|
-| a/package-1   | New        | -     | 1.0.0  | [Compare](https://example.com/r/1.0.0)        |
-| a/no-link-1   | New        | -     | 1.0.0  |                                               |
-| a/package-2   | Upgraded   | 1.0.0 | 1.2.0  | [Compare](https://example.com/c/1.0.0..1.2.0) |
-| a/package-3   | Downgraded | 2.0.0 | 1.1.1  | [Compare](https://example.com/c/2.0.0..1.1.1) |
-| a/no-link-2   | Downgraded | 2.0.0 | 1.1.1  |                                               |
+| Prod Packages | Operation  | Base    | Target | Link                                          |
+|---------------|------------|---------|--------|-----------------------------------------------|
+| a/package-1   | New        | -       | 1.0.0  | [Compare](https://example.com/r/1.0.0)        |
+| a/no-link-1   | New        | -       | 1.0.0  |                                               |
+| a/package-2   | Upgraded   | 1.0.0   | 1.2.0  | [Compare](https://example.com/c/1.0.0..1.2.0) |
+| a/package-3   | Downgraded | 2.0.0   | 1.1.1  | [Compare](https://example.com/c/2.0.0..1.1.1) |
+| a/no-link-2   | Downgraded | 2.0.0   | 1.1.1  |                                               |
+| php           | Upgraded   | >=7.4.6 | ^8.0   |                                               |
 
 | Dev Packages | Operation  | Base               | Target | Link                                               |
 |--------------|------------|--------------------|--------|----------------------------------------------------|
@@ -31,13 +32,14 @@ OUTPUT;
         }
 
         return <<<OUTPUT
-| Prod Packages | Operation  | Base  | Target |
-|---------------|------------|-------|--------|
-| a/package-1   | New        | -     | 1.0.0  |
-| a/no-link-1   | New        | -     | 1.0.0  |
-| a/package-2   | Upgraded   | 1.0.0 | 1.2.0  |
-| a/package-3   | Downgraded | 2.0.0 | 1.1.1  |
-| a/no-link-2   | Downgraded | 2.0.0 | 1.1.1  |
+| Prod Packages | Operation  | Base    | Target |
+|---------------|------------|---------|--------|
+| a/package-1   | New        | -       | 1.0.0  |
+| a/no-link-1   | New        | -       | 1.0.0  |
+| a/package-2   | Upgraded   | 1.0.0   | 1.2.0  |
+| a/package-3   | Downgraded | 2.0.0   | 1.1.1  |
+| a/no-link-2   | Downgraded | 2.0.0   | 1.1.1  |
+| php           | Upgraded   | >=7.4.6 | ^8.0   |
 
 | Dev Packages | Operation  | Base               | Target |
 |--------------|------------|--------------------|--------|


### PR DESCRIPTION
Changing version constraints for platform packages (like `"php": "^7.4.6"` -> `"php": "^8.0"`) causes issue during version parsing. This is because platform packages versions are stored as constraints instead of normalized version strings.