### PR TITLE
Fix generating links for gitlab repos in subgroups

### DIFF
--- a/src/Url/GitGenerator.php
+++ b/src/Url/GitGenerator.php
@@ -38,7 +38,7 @@ abstract class GitGenerator implements UrlGenerator
     protected function getUser(PackageInterface $package)
     {
         return preg_replace(
-            "/^https:\/\/{$this->getQuotedDomain()}\/([^\/]+)\/([^\/]+)$/",
+            "/^https:\/\/{$this->getQuotedDomain()}\/(.+)\/([^\/]+)$/",
             '$1',
             $this->getRepositoryUrl($package)
         );
@@ -50,7 +50,7 @@ abstract class GitGenerator implements UrlGenerator
     protected function getRepo(PackageInterface $package)
     {
         return preg_replace(
-            "/^https:\/\/{$this->getQuotedDomain()}\/([^\/]+)\/([^\/]+)$/",
+            "/^https:\/\/{$this->getQuotedDomain()}\/(.+)\/([^\/]+)$/",
             '$2',
             $this->getRepositoryUrl($package)
         );
@@ -62,7 +62,7 @@ abstract class GitGenerator implements UrlGenerator
     protected function getRepositoryUrl(PackageInterface $package)
     {
         $httpsUrl = preg_replace(
-            "/^git@({$this->getQuotedDomain()}):([^\/]+)\/([^\/]+)(\.git)?$/",
+            "/^git@({$this->getQuotedDomain()}):(.+)\/([^\/]+)(\.git)?$/",
             'https://$1/$2/$3',
             $package->getSourceUrl()
         );

--- a/src/Url/GitlabGenerator.php
+++ b/src/Url/GitlabGenerator.php
@@ -40,7 +40,7 @@ class GitlabGenerator extends GitGenerator
         $baseMaintainer = $this->getUser($initialPackage);
         $targetMaintainer = $this->getUser($targetPackage);
         if ($baseMaintainer !== $targetMaintainer ) {
-            return null;
+            return $this->getReleaseUrl($targetPackage); // Could not get a compare URL, using release URL instead
         }
 
         return sprintf('%s/compare/%s...%s', $baseUrl, $this->getCompareRef($initialPackage), $this->getCompareRef($targetPackage));

--- a/src/Url/GitlabGenerator.php
+++ b/src/Url/GitlabGenerator.php
@@ -39,9 +39,11 @@ class GitlabGenerator extends GitGenerator
         $baseUrl = $this->getRepositoryUrl($initialPackage);
         $baseMaintainer = $this->getUser($initialPackage);
         $targetMaintainer = $this->getUser($targetPackage);
-        $targetVersion = ($baseMaintainer !== $targetMaintainer ? $targetMaintainer.':' : '').$this->getCompareRef($targetPackage);
+        if ($baseMaintainer !== $targetMaintainer ) {
+            return null;
+        }
 
-        return sprintf('%s/compare/%s...%s', $baseUrl, $this->getCompareRef($initialPackage), $targetVersion);
+        return sprintf('%s/compare/%s...%s', $baseUrl, $this->getCompareRef($initialPackage), $this->getCompareRef($targetPackage));
     }
 
     /**

--- a/tests/Url/GitlabGeneratorTest.php
+++ b/tests/Url/GitlabGeneratorTest.php
@@ -26,8 +26,16 @@ class GitlabGeneratorTest extends GeneratorTest
                 'https://gitlab.acme.org/acme/package/tags/3.12.1',
             ),
             'dev version' => array(
-                $this->getPackageWithSource('acme/package', 'dev-master', 'git@gitlab.acme.org:acme/package'),
+                $this->getPackageWithSource('acme/package', 'dev-master', 'git@gitlab.acme.org:ac/me/package'),
                 null,
+            ),
+            'https in subgroup' => array(
+                $this->getPackageWithSource('ac/me/package', '3.12.1', 'https://gitlab.acme.org/ac/me/package.git'),
+                'https://gitlab.acme.org/ac/me/package/tags/3.12.1',
+            ),
+            'ssh in subgroup' => array(
+                $this->getPackageWithSource('ac/me/package', '3.12.1', 'git@gitlab.acme.org:ac/me/package.git'),
+                'https://gitlab.acme.org/ac/me/package/tags/3.12.1',
             ),
         );
     }
@@ -58,16 +66,31 @@ class GitlabGeneratorTest extends GeneratorTest
             'compare with base fork' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://gitlab.acme.org/IonBazan/package.git'),
                 $this->getPackageWithSource('acme/package', '3.12.1', 'https://gitlab.acme.org/acme/package.git'),
-                'https://gitlab.acme.org/IonBazan/package/compare/3.12.0...acme:3.12.1',
+                null,
             ),
             'compare with head fork' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://gitlab.acme.org/acme/package.git'),
                 $this->getPackageWithSource('acme/package', '3.12.1', 'https://gitlab.acme.org/IonBazan/package.git'),
-                'https://gitlab.acme.org/acme/package/compare/3.12.0...IonBazan:3.12.1',
+                null,
             ),
             'compare with different repository provider' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://gitlab.acme.org/acme/package.git'),
                 $this->getPackageWithSource('acme/package', '3.12.1', 'https://gitlab.org/acme/package.git'),
+                null,
+            ),
+            'compare from https in subgroup' => array(
+                $this->getPackageWithSource('acme/package', '3.12.0', 'https://gitlab.acme.org/ac/me/package'),
+                $this->getPackageWithSource('acme/package', '3.12.1', 'https://gitlab.acme.org/ac/me/package'),
+                'https://gitlab.acme.org/ac/me/package/compare/3.12.0...3.12.1',
+            ),
+            'compare from ssh in subgroup' => array(
+                $this->getPackageWithSource('acme/package', '3.12.0', 'git@gitlab.acme.org:ac/me/package.git'),
+                $this->getPackageWithSource('acme/package', '3.12.1', 'git@gitlab.acme.org:ac/me/package.git'),
+                'https://gitlab.acme.org/ac/me/package/compare/3.12.0...3.12.1',
+            ),
+            'compare with base fork from subgroups' => array(
+                $this->getPackageWithSource('acme/package', '3.12.0', 'https://gitlab.acme.org/Ion/Bazan/package.git'),
+                $this->getPackageWithSource('acme/package', '3.12.1', 'https://gitlab.acme.org/ac/me/package.git'),
                 null,
             ),
         );

--- a/tests/Url/GitlabGeneratorTest.php
+++ b/tests/Url/GitlabGeneratorTest.php
@@ -66,12 +66,12 @@ class GitlabGeneratorTest extends GeneratorTest
             'compare with base fork' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://gitlab.acme.org/IonBazan/package.git'),
                 $this->getPackageWithSource('acme/package', '3.12.1', 'https://gitlab.acme.org/acme/package.git'),
-                null,
+                'https://gitlab.acme.org/acme/package/tags/3.12.1',
             ),
             'compare with head fork' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://gitlab.acme.org/acme/package.git'),
                 $this->getPackageWithSource('acme/package', '3.12.1', 'https://gitlab.acme.org/IonBazan/package.git'),
-                null,
+                'https://gitlab.acme.org/IonBazan/package/tags/3.12.1',
             ),
             'compare with different repository provider' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://gitlab.acme.org/acme/package.git'),
@@ -91,7 +91,7 @@ class GitlabGeneratorTest extends GeneratorTest
             'compare with base fork from subgroups' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://gitlab.acme.org/Ion/Bazan/package.git'),
                 $this->getPackageWithSource('acme/package', '3.12.1', 'https://gitlab.acme.org/ac/me/package.git'),
-                null,
+                'https://gitlab.acme.org/ac/me/package/tags/3.12.1',
             ),
         );
     }


### PR DESCRIPTION
Hey,

first of all, thanks for the great package. I found a minor bug when using it with gitlab repositories.

Gitlab allows creating subgroups, for instance here is one of the gitlab repostiories: https://gitlab.com/gitlab-org/ci-cd/shared-runners/images/gcp/windows-containers . The source git path for that repo has many `/` signs: 

```
git@gitlab.com:gitlab-org/ci-cd/shared-runners/images/gcp/windows-containers.git
```

The regex that is used to substitute package url does not allow for that, it only allows single `/` sign in path. As a result, it generated a line like that for me:

```
| istruct/component-developer       | Downgraded | 0.5.2 | dev-feature/tools a463df1 | [Compare](git@git.mydomain.example.com:istruct/component/developer/compare/0.5.2...a463df1)    |
```

As you can see, it left the `git@` part in the comparison link, because `preg_replace` pattern didn't match anything.

I propose a simple fix that allows `/` in repository namespaces.

Additionally, comparison links across forks like:

```
https://gitlab.acme.org/IonBazan/package/compare/3.12.0...acme:3.12.1
```

don't work on gitlab for me, they have slightly different syntax: 

```
https://gitlab.acme.org/IonBazan/package/compare/3.12.0...3.12.1?from_project_id=27069907
```

Unfortunately, we cannot generate it without knowing internal numerical project id, so I propose to simply return null in gitlab links generator when project namespaces don't match.
