### PR TITLE
Add strict mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,6 @@
 /.github export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.php_cs.dist export-ignore
+.php-cs-fixer.dist.php export-ignore
 phpunit.xml.dist export-ignore
 infection.json.dist export-ignore

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ composer diff -p # include platform dependencies
 composer diff -f json # Output as JSON instead of table
 ```
 
+### Strict mode
+
+To help you control your dependencies, you may pass `--strict` option when running in CI. If there are any changes detected, a non-zero exit code will be returned.
+
+Exit code of the command is built using following bit flags:
+
+*  `0` - OK.
+*  `1` - General error.
+*  `2` - There were changes in prod packages.
+*  `4` - There were changes is dev packages.
+*  `8` - There were downgrades in prod packages.
+* `16` - There were downgrades in dev packages.
+
+You may check for individual flags or simply check if the status is greater or equal 8 if you don't want to downgrade any package.
+
 # Similar packages
 
 While there are several existing packages offering similar functionality:

--- a/src/Formatter/AbstractFormatter.php
+++ b/src/Formatter/AbstractFormatter.php
@@ -7,11 +7,8 @@ use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Package\PackageInterface;
-use Composer\Semver\Semver;
-use Composer\Semver\VersionParser;
 use IonBazan\ComposerDiff\Url\GeneratorContainer;
 use Symfony\Component\Console\Output\OutputInterface;
-use UnexpectedValueException;
 
 abstract class AbstractFormatter implements Formatter
 {
@@ -73,22 +70,5 @@ abstract class AbstractFormatter implements Formatter
         }
 
         return $generator->getReleaseUrl($package);
-    }
-
-    /**
-     * @return bool
-     */
-    protected static function isUpgrade(UpdateOperation $operation)
-    {
-        $versionParser = new VersionParser();
-        try {
-            $normalizedFrom = $versionParser->normalize($operation->getInitialPackage()->getVersion());
-            $normalizedTo = $versionParser->normalize($operation->getTargetPackage()->getVersion());
-        } catch (UnexpectedValueException $e) {
-            return true; // Consider as upgrade if versions are not parsable
-        }
-        $sorted = Semver::sort(array($normalizedTo, $normalizedFrom));
-
-        return $sorted[0] === $normalizedFrom;
     }
 }

--- a/src/Formatter/JsonFormatter.php
+++ b/src/Formatter/JsonFormatter.php
@@ -6,6 +6,7 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
+use IonBazan\ComposerDiff\PackageDiff;
 
 class JsonFormatter extends AbstractFormatter
 {
@@ -78,7 +79,7 @@ class JsonFormatter extends AbstractFormatter
         if ($operation instanceof UpdateOperation) {
             return array(
                 'name' => $operation->getInitialPackage()->getName(),
-                'operation' => self::isUpgrade($operation) ? 'upgrade' : 'downgrade',
+                'operation' => PackageDiff::isUpgrade($operation) ? 'upgrade' : 'downgrade',
                 'version_base' => $operation->getInitialPackage()->getFullPrettyVersion(),
                 'version_target' => $operation->getTargetPackage()->getFullPrettyVersion(),
             );

--- a/src/Formatter/MarkdownListFormatter.php
+++ b/src/Formatter/MarkdownListFormatter.php
@@ -6,6 +6,7 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
+use IonBazan\ComposerDiff\PackageDiff;
 
 class MarkdownListFormatter extends MarkdownFormatter
 {
@@ -58,7 +59,7 @@ class MarkdownListFormatter extends MarkdownFormatter
         }
 
         if ($operation instanceof UpdateOperation) {
-            $isUpgrade = self::isUpgrade($operation);
+            $isUpgrade = PackageDiff::isUpgrade($operation);
 
             return sprintf(
                 ' - %s <fg=green>%s</> (<fg=yellow>%s</> => <fg=yellow>%s</>)%s',

--- a/src/Formatter/MarkdownTableFormatter.php
+++ b/src/Formatter/MarkdownTableFormatter.php
@@ -7,6 +7,7 @@ use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use IonBazan\ComposerDiff\Formatter\Helper\Table;
+use IonBazan\ComposerDiff\PackageDiff;
 
 class MarkdownTableFormatter extends MarkdownFormatter
 {
@@ -68,7 +69,7 @@ class MarkdownTableFormatter extends MarkdownFormatter
         if ($operation instanceof UpdateOperation) {
             return array(
                 $operation->getInitialPackage()->getName(),
-                self::isUpgrade($operation) ? '<fg=cyan>Upgraded</>' : '<fg=yellow>Downgraded</>',
+                PackageDiff::isUpgrade($operation) ? '<fg=cyan>Upgraded</>' : '<fg=yellow>Downgraded</>',
                 $operation->getInitialPackage()->getFullPrettyVersion(),
                 $operation->getTargetPackage()->getFullPrettyVersion(),
             );


### PR DESCRIPTION
This PR adds `--strict` flag that triggers a non-zero exit code. 
The exit code is a bit flag created as follows:


*  `0` - OK.
*  `1` - General error.
*  `2` - There were changes in prod packages.
*  `4` - There were changes is dev packages.
*  `8` - There were downgrades in prod packages.
* `16` - There were downgrades in dev packages.