### PR TITLE
Add "changed" status, refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
+          - '8.1'
         include:
           - php-versions: '5.3'
             composer-flags: '--prefer-lowest'
@@ -50,15 +51,14 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
       - name: Run mutation tests
-        if: ${{ matrix.php-versions == 7.4 && matrix.operating-system == 'ubuntu-latest' }}
+        if: ${{ matrix.php-versions == 8.0 && matrix.operating-system == 'ubuntu-latest' }}
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
         run: |
           composer req infection/infection
           vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=100 -s -j4
       - name: Run phpstan
-        if: ${{ matrix.php-versions >= 7.1 && matrix.php-versions < 8.0 }}
+        if: ${{ matrix.php-versions == 8.0 && matrix.operating-system == 'ubuntu-latest' }}
         run: |
           composer req phpstan/phpstan
-          vendor/bin/phpstan analyse src -l 6
-
+          vendor/bin/phpstan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
           - '8.0'
           - '8.1'
         include:
+          - php-versions: '7.0'
+            composer-flags: '--prefer-lowest'
+            operating-system: ubuntu-latest
           - php-versions: '5.3'
             composer-flags: '--prefer-lowest'
             operating-system: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Composer Diff Plugin
 
+[![PHP 5.3+ | 7.x | 8.x](https://img.shields.io/badge/PHP-^5.3_|_^7_|_^8-blue.svg)](https://packagist.org/packages/ion-bazan/composer-diff)
+[![Composer v1 | v2](https://img.shields.io/badge/Composer-^1.1_|_^2-success.svg)](https://packagist.org/packages/ion-bazan/composer-diff)
 [![Latest version](https://img.shields.io/packagist/v/ion-bazan/composer-diff.svg)](https://packagist.org/packages/ion-bazan/composer-diff)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/IonBazan/composer-diff/Tests)](https://github.com/IonBazan/composer-diff/actions)
 [![PHP version](https://img.shields.io/packagist/php-v/ion-bazan/composer-diff.svg)](https://packagist.org/packages/ion-bazan/composer-diff)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![PHP 5.3+ | 7.x | 8.x](https://img.shields.io/badge/PHP-^5.3_|_^7_|_^8-blue.svg)](https://packagist.org/packages/ion-bazan/composer-diff)
 [![Composer v1 | v2](https://img.shields.io/badge/Composer-^1.1_|_^2-success.svg)](https://packagist.org/packages/ion-bazan/composer-diff)
+[![Dependencies: 0](https://img.shields.io/badge/dependencies-0-success.svg)](https://packagist.org/packages/ion-bazan/composer-diff)
 [![Latest version](https://img.shields.io/packagist/v/ion-bazan/composer-diff.svg)](https://packagist.org/packages/ion-bazan/composer-diff)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/IonBazan/composer-diff/Tests)](https://github.com/IonBazan/composer-diff/actions)
-[![PHP version](https://img.shields.io/packagist/php-v/ion-bazan/composer-diff.svg)](https://packagist.org/packages/ion-bazan/composer-diff)
 [![Codecov](https://img.shields.io/codecov/c/gh/IonBazan/composer-diff)](https://codecov.io/gh/IonBazan/composer-diff)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FIonBazan%2Fcomposer-diff%2Fmaster)](https://dashboard.stryker-mutator.io/reports/github.com/IonBazan/composer-diff/master)
 [![Downloads](https://img.shields.io/packagist/dt/ion-bazan/composer-diff.svg)](https://packagist.org/packages/ion-bazan/composer-diff)

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "platform-check": false
     },
     "extra": {
-        "class": "IonBazan\\ComposerDiff\\Plugin"
+        "class": "IonBazan\\ComposerDiff\\Composer\\Plugin"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: 6
+    paths:
+        - src
+    checkGenericClassInNonGenericObjectType: true
+    checkMissingIterableValueType: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,7 @@
 >
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <env name="COMPOSER_DISABLE_XDEBUG_WARN" value="1"/>
     </php>
     <testsuites>
         <testsuite name="Composer Diff Test Suite">

--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace IonBazan\ComposerDiff;
+namespace IonBazan\ComposerDiff\Composer;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;

--- a/src/Diff/DiffEntries.php
+++ b/src/Diff/DiffEntries.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Diff;
+
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+
+/**
+ * @implements IteratorAggregate<int, DiffEntry>
+ */
+class DiffEntries implements IteratorAggregate, Countable
+{
+    /** @var DiffEntry[] */
+    private $entries;
+
+    /**
+     * @param DiffEntry[] $entries
+     */
+    public function __construct(array $entries)
+    {
+        $this->entries = $entries;
+    }
+
+    /**
+     * @return ArrayIterator<int, DiffEntry>
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->entries);
+    }
+
+    public function count()
+    {
+        return \count($this->entries);
+    }
+}

--- a/src/Diff/DiffEntry.php
+++ b/src/Diff/DiffEntry.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Diff;
+
+use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\OperationInterface;
+use Composer\DependencyResolver\Operation\UninstallOperation;
+use Composer\DependencyResolver\Operation\UpdateOperation;
+
+class DiffEntry
+{
+    const TYPE_INSTALL = 'install';
+    const TYPE_UPGRADE = 'upgrade';
+    const TYPE_DOWNGRADE = 'downgrade';
+    const TYPE_REMOVE = 'remove';
+    const TYPE_CHANGE = 'change';
+
+    /** @var OperationInterface */
+    private $operation;
+
+    /** @var string */
+    private $type;
+
+    public function __construct(OperationInterface $operation)
+    {
+        $this->operation = $operation;
+        $this->type = $this->determineType();
+    }
+
+    /**
+     * @return OperationInterface
+     */
+    public function getOperation()
+    {
+        return $this->operation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInstall()
+    {
+        return self::TYPE_INSTALL === $this->type;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isUpgrade()
+    {
+        return self::TYPE_UPGRADE === $this->type;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDowngrade()
+    {
+        return self::TYPE_DOWNGRADE === $this->type;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRemove()
+    {
+        return self::TYPE_REMOVE === $this->type;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isChange()
+    {
+        return self::TYPE_CHANGE === $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    private function determineType()
+    {
+        if ($this->operation instanceof InstallOperation) {
+            return self::TYPE_INSTALL;
+        }
+
+        if ($this->operation instanceof UninstallOperation) {
+            return self::TYPE_REMOVE;
+        }
+
+        if ($this->operation instanceof UpdateOperation) {
+            $upgrade = VersionComparator::isUpgrade($this->operation);
+
+            if (null === $upgrade) {
+                return self::TYPE_CHANGE;
+            }
+
+            return $upgrade ? self::TYPE_UPGRADE : self::TYPE_DOWNGRADE;
+        }
+
+        return self::TYPE_CHANGE;
+    }
+}

--- a/src/Diff/VersionComparator.php
+++ b/src/Diff/VersionComparator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Diff;
+
+use Composer\DependencyResolver\Operation\UpdateOperation;
+use Composer\Semver\Semver;
+use Composer\Semver\VersionParser;
+use UnexpectedValueException;
+
+class VersionComparator
+{
+    /**
+     * @return bool|null true if it's upgrade, false if it's downgrade, null if it is a change
+     */
+    public static function isUpgrade(UpdateOperation $operation)
+    {
+        $versionParser = new VersionParser();
+        try {
+            $normalizedFrom = $versionParser->normalize($operation->getInitialPackage()->getVersion());
+            $normalizedTo = $versionParser->normalize($operation->getTargetPackage()->getVersion());
+        } catch (UnexpectedValueException $e) {
+            return null; // Consider as change if versions are not parseable
+        }
+
+        /* @infection-ignore-all False-positive, handled by build matrix with Composer 1 installed */
+        if (
+            '9999999-dev' === $normalizedFrom
+            || '9999999-dev' === $normalizedTo // BC for Composer 1.x
+            || 0 === strpos($normalizedFrom, 'dev-')
+            || 0 === strpos($normalizedTo, 'dev-')
+        ) {
+            return null;
+        }
+
+        $sorted = Semver::sort(array($normalizedTo, $normalizedFrom));
+
+        return $sorted[0] === $normalizedFrom;
+    }
+}

--- a/src/Formatter/AbstractFormatter.php
+++ b/src/Formatter/AbstractFormatter.php
@@ -3,10 +3,10 @@
 namespace IonBazan\ComposerDiff\Formatter;
 
 use Composer\DependencyResolver\Operation\InstallOperation;
-use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Package\PackageInterface;
+use IonBazan\ComposerDiff\Diff\DiffEntry;
 use IonBazan\ComposerDiff\Url\GeneratorContainer;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -31,8 +31,10 @@ abstract class AbstractFormatter implements Formatter
     /**
      * @return string|null
      */
-    public function getUrl(OperationInterface $operation)
+    public function getUrl(DiffEntry $entry)
     {
+        $operation = $entry->getOperation();
+
         if ($operation instanceof UpdateOperation) {
             return $this->getCompareUrl($operation->getInitialPackage(), $operation->getTargetPackage());
         }

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -2,30 +2,28 @@
 
 namespace IonBazan\ComposerDiff\Formatter;
 
-use Composer\DependencyResolver\Operation\OperationInterface;
+use IonBazan\ComposerDiff\Diff\DiffEntries;
+use IonBazan\ComposerDiff\Diff\DiffEntry;
 
 interface Formatter
 {
     /**
-     * @param OperationInterface[] $prodOperations
-     * @param OperationInterface[] $devOperations
-     * @param bool                 $withUrls
+     * @param bool $withUrls
      *
      * @return void
      */
-    public function render(array $prodOperations, array $devOperations, $withUrls);
+    public function render(DiffEntries $prodEntries, DiffEntries $devEntries, $withUrls);
 
     /**
-     * @param OperationInterface[] $operations
-     * @param string               $title
-     * @param bool                 $withUrls
+     * @param string $title
+     * @param bool   $withUrls
      *
      * @return void
      */
-    public function renderSingle(array $operations, $title, $withUrls);
+    public function renderSingle(DiffEntries $entries, $title, $withUrls);
 
     /**
      * @return string|null
      */
-    public function getUrl(OperationInterface $operation);
+    public function getUrl(DiffEntry $entry);
 }

--- a/src/PackageDiff.php
+++ b/src/PackageDiff.php
@@ -9,9 +9,8 @@ use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Package\CompletePackage;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Repository\ArrayRepository;
-use Composer\Semver\Semver;
-use Composer\Semver\VersionParser;
-use UnexpectedValueException;
+use IonBazan\ComposerDiff\Diff\DiffEntries;
+use IonBazan\ComposerDiff\Diff\DiffEntry;
 
 class PackageDiff
 {
@@ -23,7 +22,7 @@ class PackageDiff
      * @param bool   $dev
      * @param bool   $withPlatform
      *
-     * @return OperationInterface[]
+     * @return DiffEntries
      */
     public function getPackageDiff($from, $to, $dev, $withPlatform)
     {
@@ -50,24 +49,9 @@ class PackageDiff
             }
         }
 
-        return $operations;
-    }
-
-    /**
-     * @return bool
-     */
-    public static function isUpgrade(UpdateOperation $operation)
-    {
-        $versionParser = new VersionParser();
-        try {
-            $normalizedFrom = $versionParser->normalize($operation->getInitialPackage()->getVersion());
-            $normalizedTo = $versionParser->normalize($operation->getTargetPackage()->getVersion());
-        } catch (UnexpectedValueException $e) {
-            return true; // Consider as upgrade if versions are not parsable
-        }
-        $sorted = Semver::sort(array($normalizedTo, $normalizedFrom));
-
-        return $sorted[0] === $normalizedFrom;
+        return new DiffEntries(array_map(function (OperationInterface $operation) {
+            return new DiffEntry($operation);
+        }, $operations));
     }
 
     /**

--- a/tests/Command/DiffCommandTest.php
+++ b/tests/Command/DiffCommandTest.php
@@ -24,7 +24,7 @@ class DiffCommandTest extends TestCase
         $diff->expects($this->once())
             ->method('getPackageDiff')
             ->with($this->isType('string'), $this->isType('string'), false, false)
-            ->willReturn(array(
+            ->willReturn($this->getEntries(array(
                 new InstallOperation($this->getPackageWithSource('a/package-1', '1.0.0', 'github.com')),
                 new UpdateOperation($this->getPackageWithSource('a/package-2', '1.0.0', 'github.com'), $this->getPackageWithSource('a/package-2', '1.2.0', 'github.com')),
                 new UninstallOperation($this->getPackageWithSource('a/package-3', '0.1.1', 'github.com')),
@@ -32,7 +32,7 @@ class DiffCommandTest extends TestCase
                 new UninstallOperation($this->getPackageWithSource('a/package-5', '0.1.1', 'gitlab2.org')),
                 new UninstallOperation($this->getPackageWithSource('a/package-6', '0.1.1', 'gitlab3.org')),
                 new UpdateOperation($this->getPackageWithSource('a/package-7', '1.2.0', 'github.com'), $this->getPackageWithSource('a/package-7', '1.0.0', 'github.com')),
-            ))
+            )))
         ;
         $result = $tester->execute($options);
         $this->assertSame(0, $result);
@@ -53,7 +53,7 @@ class DiffCommandTest extends TestCase
         $diff->expects($this->exactly(2))
             ->method('getPackageDiff')
             ->with($this->isType('string'), $this->isType('string'), $this->isType('boolean'), false)
-            ->willReturnOnConsecutiveCalls($prodOperations, $devOperations)
+            ->willReturnOnConsecutiveCalls($this->getEntries($prodOperations), $this->getEntries($devOperations))
         ;
         $this->assertSame($exitCode, $tester->execute(array('--strict' => null)));
     }

--- a/tests/Composer/PluginTest.php
+++ b/tests/Composer/PluginTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace IonBazan\ComposerDiff\Tests;
+namespace IonBazan\ComposerDiff\Tests\Composer;
 
-use IonBazan\ComposerDiff\Plugin;
+use IonBazan\ComposerDiff\Composer\Plugin;
+use IonBazan\ComposerDiff\Tests\TestCase;
 
 class PluginTest extends TestCase
 {

--- a/tests/Diff/DiffEntryTest.php
+++ b/tests/Diff/DiffEntryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Tests\Diff;
+
+use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\OperationInterface;
+use Composer\DependencyResolver\Operation\UninstallOperation;
+use Composer\DependencyResolver\Operation\UpdateOperation;
+use IonBazan\ComposerDiff\Diff\DiffEntry;
+use IonBazan\ComposerDiff\Tests\TestCase;
+
+class DiffEntryTest extends TestCase
+{
+    /**
+     * @param string $expectedType
+     *
+     * @dataProvider operationTypeProvider
+     */
+    public function testOperationTypeGuessing($expectedType, OperationInterface $operation)
+    {
+        $entry = new DiffEntry($operation);
+        $this->assertSame($expectedType, $entry->getType());
+        $this->assertTrue($entry->{'is'.ucfirst($expectedType)}());
+    }
+
+    public function operationTypeProvider()
+    {
+        return array(
+            'Install operation' => array(
+                'install',
+                new InstallOperation($this->getPackage('a/package-1', '1.0.0')),
+            ),
+            'Remove operation' => array(
+                'remove',
+                new UninstallOperation($this->getPackage('a/package-1', '1.0.0')),
+            ),
+            'Upgrade operation' => array(
+                'upgrade',
+                new UpdateOperation($this->getPackage('a/package-1', '1.0.0'), $this->getPackage('a/package-1', '2.0.0')),
+            ),
+            'Downgrade operation' => array(
+                'downgrade',
+                new UpdateOperation($this->getPackage('a/package-1', '2.0.0'), $this->getPackage('a/package-1', '1.0.0')),
+            ),
+            'Change operation (base branch)' => array(
+                'change',
+                new UpdateOperation($this->getPackage('a/package-1', 'dev-master', 'dev-master 1234567'), $this->getPackage('a/package-1', '1.0.0')),
+            ),
+            'Change operation (target branch)' => array(
+                'change',
+                new UpdateOperation($this->getPackage('a/package-1', '1.0.0'), $this->getPackage('a/package-1', 'dev-master', 'dev-master 1234567')),
+            ),
+            'Change operation (both branch)' => array(
+                'change',
+                new UpdateOperation($this->getPackage('a/package-1', 'dev-master', 'dev-master 7654321'), $this->getPackage('a/package-1', 'dev-master', 'dev-master 1234567')),
+            ),
+            'Change operation (both custom branch)' => array(
+                'change',
+                new UpdateOperation($this->getPackage('a/package-1', 'dev-develop', 'dev-develop 7654321'), $this->getPackage('a/package-1', 'dev-develop', 'dev-develop 1234567')),
+            ),
+            'Change operation (target branch and base custom branch)' => array(
+                'change',
+                new UpdateOperation($this->getPackage('a/package-1', 'dev-develop', 'dev-develop 7654321'), $this->getPackage('a/package-1', 'dev-master', 'dev-master 1234567')),
+            ),
+            'Change operation (base branch and target custom branch)' => array(
+                'change',
+                new UpdateOperation($this->getPackage('a/package-1', 'dev-master', 'dev-master 7654321'), $this->getPackage('a/package-1', 'dev-develop', 'dev-develop 1234567')),
+            ),
+            'Change operation (target custom branch)' => array(
+                'change',
+                new UpdateOperation($this->getPackage('a/package-1', '1.0.0'), $this->getPackage('a/package-1', 'dev-develop', 'dev-develop 1234567')),
+            ),
+            'Change operation (base custom branch)' => array(
+                'change',
+                new UpdateOperation($this->getPackage('a/package-1', 'dev-develop', 'dev-develop 7654321'), $this->getPackage('a/package-1', '1.0.0')),
+            ),
+            'Change operation (BC with Composer 1 master as base)' => array(
+                'change',
+                new UpdateOperation($this->getPackage('a/package-1', 'master', 'master 7654321'), $this->getPackage('a/package-1', '1.0.0')),
+            ),
+            'Change operation (BC with Composer 1 master as target)' => array(
+                'change',
+                new UpdateOperation($this->getPackage('a/package-1', '1.0.0'), $this->getPackage('a/package-1', 'master', 'master 1234567')),
+            ),
+        );
+    }
+}

--- a/tests/Formatter/FormatterTest.php
+++ b/tests/Formatter/FormatterTest.php
@@ -6,6 +6,8 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Package\PackageInterface;
+use IonBazan\ComposerDiff\Diff\DiffEntries;
+use IonBazan\ComposerDiff\Diff\DiffEntry;
 use IonBazan\ComposerDiff\Formatter\Formatter;
 use IonBazan\ComposerDiff\Tests\TestCase;
 use IonBazan\ComposerDiff\Url\GeneratorContainer;
@@ -19,7 +21,7 @@ abstract class FormatterTest extends TestCase
     {
         $output = new StreamOutput(fopen('php://memory', 'wb', false));
         $formatter = $this->getFormatter($output, $this->getGenerators());
-        $formatter->render(array(), array(), true);
+        $formatter->render(new DiffEntries(array()), new DiffEntries(array()), true);
         $this->assertSame(static::getEmptyOutput(), $this->getDisplay($output));
     }
 
@@ -28,7 +30,7 @@ abstract class FormatterTest extends TestCase
         $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
         $operation = $this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock();
         $formatter = $this->getFormatter($output, $this->getGenerators());
-        $this->assertNull($formatter->getUrl($operation));
+        $this->assertNull($formatter->getUrl(new DiffEntry($operation)));
     }
 
     /**
@@ -54,7 +56,7 @@ abstract class FormatterTest extends TestCase
             new UninstallOperation($this->getPackage('a/package-4', '0.1.1')),
             new UninstallOperation($this->getPackage('a/no-link-2', '0.1.1')),
         );
-        $formatter->render($prodPackages, $devPackages, $withUrls);
+        $formatter->render($this->getEntries($prodPackages), $this->getEntries($devPackages), $withUrls);
         $this->assertSame($this->getSampleOutput($withUrls), $this->getDisplay($output));
     }
 
@@ -62,9 +64,9 @@ abstract class FormatterTest extends TestCase
     {
         $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
         $this->setExpectedException('InvalidArgumentException', 'Invalid operation');
-        $this->getFormatter($output, $this->getGenerators())->render(array(
+        $this->getFormatter($output, $this->getGenerators())->render($this->getEntries(array(
             $this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock(),
-        ), array(), false);
+        )), $this->getEntries(array()), false);
     }
 
     /**

--- a/tests/Formatter/JsonFormatterTest.php
+++ b/tests/Formatter/JsonFormatterTest.php
@@ -26,7 +26,7 @@ class JsonFormatterTest extends FormatterTest
         );
         $output = new StreamOutput(fopen('php://memory', 'wb', false));
         $formatter = $this->getFormatter($output, $this->getGenerators());
-        $formatter->renderSingle($sampleData, 'test', true);
+        $formatter->renderSingle($this->getEntries($sampleData), 'test', true);
 
         $this->assertSame(self::formatOutput(array(
             'a/package-1' => array(
@@ -66,7 +66,7 @@ class JsonFormatterTest extends FormatterTest
                 ),
             'a/package-5' => array(
                     'name' => 'a/package-5',
-                    'operation' => 'downgrade',
+                    'operation' => 'change',
                     'version_base' => 'dev-master 1234567',
                     'version_target' => '1.1.1',
                     'compare' => 'https://example.com/c/dev-master..1.1.1',
@@ -123,7 +123,7 @@ class JsonFormatterTest extends FormatterTest
                             ),
                         'php' => array(
                             'name' => 'php',
-                            'operation' => 'upgrade',
+                            'operation' => 'change',
                             'version_base' => '>=7.4.6',
                             'version_target' => '^8.0',
                             'compare' => null,
@@ -132,7 +132,7 @@ class JsonFormatterTest extends FormatterTest
                 'packages-dev' => array(
                         'a/package-5' => array(
                                 'name' => 'a/package-5',
-                                'operation' => 'downgrade',
+                                'operation' => 'change',
                                 'version_base' => 'dev-master 1234567',
                                 'version_target' => '1.1.1',
                                 'compare' => 'https://example.com/c/dev-master..1.1.1',
@@ -189,7 +189,7 @@ class JsonFormatterTest extends FormatterTest
                 ),
                 'php' => array(
                     'name' => 'php',
-                    'operation' => 'upgrade',
+                    'operation' => 'change',
                     'version_base' => '>=7.4.6',
                     'version_target' => '^8.0',
                 ),
@@ -197,7 +197,7 @@ class JsonFormatterTest extends FormatterTest
             'packages-dev' => array(
                 'a/package-5' => array(
                     'name' => 'a/package-5',
-                    'operation' => 'downgrade',
+                    'operation' => 'change',
                     'version_base' => 'dev-master 1234567',
                     'version_target' => '1.1.1',
                 ),

--- a/tests/Formatter/MarkdownListFormatterTest.php
+++ b/tests/Formatter/MarkdownListFormatterTest.php
@@ -20,12 +20,12 @@ Prod Packages
  - Upgrade a/package-2 (1.0.0 => 1.2.0) [Compare](https://example.com/c/1.0.0..1.2.0)
  - Downgrade a/package-3 (2.0.0 => 1.1.1) [Compare](https://example.com/c/2.0.0..1.1.1)
  - Downgrade a/no-link-2 (2.0.0 => 1.1.1) 
- - Upgrade php (>=7.4.6 => ^8.0) 
+ - Change php (>=7.4.6 => ^8.0) 
 
 Dev Packages
 ============
 
- - Downgrade a/package-5 (dev-master 1234567 => 1.1.1) [Compare](https://example.com/c/dev-master..1.1.1)
+ - Change a/package-5 (dev-master 1234567 => 1.1.1) [Compare](https://example.com/c/dev-master..1.1.1)
  - Uninstall a/package-4 (0.1.1) [Compare](https://example.com/r/0.1.1)
  - Uninstall a/no-link-2 (0.1.1) 
 
@@ -42,12 +42,12 @@ Prod Packages
  - Upgrade a/package-2 (1.0.0 => 1.2.0)
  - Downgrade a/package-3 (2.0.0 => 1.1.1)
  - Downgrade a/no-link-2 (2.0.0 => 1.1.1)
- - Upgrade php (>=7.4.6 => ^8.0)
+ - Change php (>=7.4.6 => ^8.0)
 
 Dev Packages
 ============
 
- - Downgrade a/package-5 (dev-master 1234567 => 1.1.1)
+ - Change a/package-5 (dev-master 1234567 => 1.1.1)
  - Uninstall a/package-4 (0.1.1)
  - Uninstall a/no-link-2 (0.1.1)
 

--- a/tests/Formatter/MarkdownTableFormatterTest.php
+++ b/tests/Formatter/MarkdownTableFormatterTest.php
@@ -19,13 +19,13 @@ class MarkdownTableFormatterTest extends FormatterTest
 | a/package-2   | Upgraded   | 1.0.0   | 1.2.0  | [Compare](https://example.com/c/1.0.0..1.2.0) |
 | a/package-3   | Downgraded | 2.0.0   | 1.1.1  | [Compare](https://example.com/c/2.0.0..1.1.1) |
 | a/no-link-2   | Downgraded | 2.0.0   | 1.1.1  |                                               |
-| php           | Upgraded   | >=7.4.6 | ^8.0   |                                               |
+| php           | Changed    | >=7.4.6 | ^8.0   |                                               |
 
-| Dev Packages | Operation  | Base               | Target | Link                                               |
-|--------------|------------|--------------------|--------|----------------------------------------------------|
-| a/package-5  | Downgraded | dev-master 1234567 | 1.1.1  | [Compare](https://example.com/c/dev-master..1.1.1) |
-| a/package-4  | Removed    | 0.1.1              | -      | [Compare](https://example.com/r/0.1.1)             |
-| a/no-link-2  | Removed    | 0.1.1              | -      |                                                    |
+| Dev Packages | Operation | Base               | Target | Link                                               |
+|--------------|-----------|--------------------|--------|----------------------------------------------------|
+| a/package-5  | Changed   | dev-master 1234567 | 1.1.1  | [Compare](https://example.com/c/dev-master..1.1.1) |
+| a/package-4  | Removed   | 0.1.1              | -      | [Compare](https://example.com/r/0.1.1)             |
+| a/no-link-2  | Removed   | 0.1.1              | -      |                                                    |
 
 
 OUTPUT;
@@ -39,13 +39,13 @@ OUTPUT;
 | a/package-2   | Upgraded   | 1.0.0   | 1.2.0  |
 | a/package-3   | Downgraded | 2.0.0   | 1.1.1  |
 | a/no-link-2   | Downgraded | 2.0.0   | 1.1.1  |
-| php           | Upgraded   | >=7.4.6 | ^8.0   |
+| php           | Changed    | >=7.4.6 | ^8.0   |
 
-| Dev Packages | Operation  | Base               | Target |
-|--------------|------------|--------------------|--------|
-| a/package-5  | Downgraded | dev-master 1234567 | 1.1.1  |
-| a/package-4  | Removed    | 0.1.1              | -      |
-| a/no-link-2  | Removed    | 0.1.1              | -      |
+| Dev Packages | Operation | Base               | Target |
+|--------------|-----------|--------------------|--------|
+| a/package-5  | Changed   | dev-master 1234567 | 1.1.1  |
+| a/package-4  | Removed   | 0.1.1              | -      |
+| a/no-link-2  | Removed   | 0.1.1              | -      |
 
 
 OUTPUT;

--- a/tests/PackageDiffTest.php
+++ b/tests/PackageDiffTest.php
@@ -3,9 +3,9 @@
 namespace IonBazan\ComposerDiff\Tests;
 
 use Composer\DependencyResolver\Operation\InstallOperation;
-use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
+use IonBazan\ComposerDiff\Diff\DiffEntry;
 use IonBazan\ComposerDiff\PackageDiff;
 
 class PackageDiffTest extends TestCase
@@ -27,7 +27,7 @@ class PackageDiffTest extends TestCase
             $withPlatform
         );
 
-        $this->assertSame($expected, array_map(array($this, 'operationToString'), $operations));
+        $this->assertSame($expected, array_map(array($this, 'entryToString'), $operations->getIterator()->getArrayCopy()));
     }
 
     public function testSameBaseAndTarget()
@@ -56,7 +56,7 @@ class PackageDiffTest extends TestCase
         $this->prepareGit();
         $operations = $diff->getPackageDiff('HEAD', '', $dev, $withPlatform);
 
-        $this->assertSame($expected, array_map(array($this, 'operationToString'), $operations));
+        $this->assertSame($expected, array_map(array($this, 'entryToString'), $operations->getIterator()->getArrayCopy()));
     }
 
     public function testInvalidGitRef()
@@ -135,8 +135,10 @@ class PackageDiffTest extends TestCase
         file_put_contents($gitDir.'/composer.lock', file_get_contents(__DIR__.'/fixtures/target/composer.lock'));
     }
 
-    private function operationToString(OperationInterface $operation)
+    private function entryToString(DiffEntry $entry)
     {
+        $operation = $entry->getOperation();
+
         if ($operation instanceof InstallOperation) {
             return sprintf('install %s %s', $operation->getPackage()->getName(), $operation->getPackage()->getPrettyVersion());
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,10 @@
 
 namespace IonBazan\ComposerDiff\Tests;
 
+use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\Package\PackageInterface;
+use IonBazan\ComposerDiff\Diff\DiffEntries;
+use IonBazan\ComposerDiff\Diff\DiffEntry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
@@ -57,5 +60,17 @@ abstract class TestCase extends BaseTestCase
         $package->method('isDev')->willReturn(0 === strpos($version, 'dev-') || '-dev' === substr($version, -4));
 
         return $package;
+    }
+
+    /**
+     * @param OperationInterface[] $operations
+     *
+     * @return DiffEntries
+     */
+    protected function getEntries(array $operations)
+    {
+        return new DiffEntries(array_map(function (OperationInterface $operation) {
+            return new DiffEntry($operation);
+        }, $operations));
     }
 }


### PR DESCRIPTION
This PR introduces new operation type: `Changed` which represents an operation where at least one of the components is referencing a branch/commit or a version constraint (for platform dependencies).

Among with the refactoring, there are following breaking changes:

- `PackageDiff::getPackageDiff()` now returns `DiffEntries` instead of `array`
- Formatters use `DiffEntries` instead `array` too
- When it's not possible to normalize the version (for example in platform dependencies, when version constraint is used), the operation is now "changed" instead of "upgraded"
- All `dev-` version changes are treated as `Changed` instead of `Upgraded` which slightly differs from Composer output (which uses more sophisticated method to decide whether it's upgrade or downgrade - for example, any `dev-master -> dev-branch` will be treated as downgrade)
