### PR TITLE
skip aliased packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Install Composer dependencies
         run: composer update -n --prefer-dist ${{ matrix.composer-flags }}
       - name: Run Tests
+        if: ${{ matrix.php-versions == 8.0 && matrix.operating-system == 'ubuntu-latest' }}
         run: vendor/bin/simple-phpunit --coverage-clover coverage.xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/src/Diff/DiffEntries.php
+++ b/src/Diff/DiffEntries.php
@@ -3,35 +3,10 @@
 namespace IonBazan\ComposerDiff\Diff;
 
 use ArrayIterator;
-use Countable;
-use IteratorAggregate;
 
 /**
- * @implements IteratorAggregate<int, DiffEntry>
+ * @extends ArrayIterator<int, DiffEntry>
  */
-class DiffEntries implements IteratorAggregate, Countable
+class DiffEntries extends ArrayIterator
 {
-    /** @var DiffEntry[] */
-    private $entries;
-
-    /**
-     * @param DiffEntry[] $entries
-     */
-    public function __construct(array $entries)
-    {
-        $this->entries = $entries;
-    }
-
-    /**
-     * @return ArrayIterator<int, DiffEntry>
-     */
-    public function getIterator()
-    {
-        return new ArrayIterator($this->entries);
-    }
-
-    public function count()
-    {
-        return \count($this->entries);
-    }
 }


### PR DESCRIPTION
This change fixes #11 - the issue where aliased packages are shown twice in the change list. 

This also adds a public `getDiff()` method that compares two repositories. This can simplify the testing but also allow developers to use this method in their applications.

Before: 
![image](https://user-images.githubusercontent.com/1985514/140312361-9458e5a6-073a-410a-895b-fc2a3e5c9bda.png)

After:
![image](https://user-images.githubusercontent.com/1985514/140312394-86863ed2-2cc3-4873-b3f6-10bef1da83c3.png)


Missing:
- [x] coverage
- [x] Mutation coverage