### PR TITLE
Handle Composer 2.3.9+ strict plugin behaviour

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
         run: |
+          composer config --no-plugins allow-plugins.infection/extension-installer true
           composer req infection/infection -W
           vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=100 -s -j4
       - name: Run phpstan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
           - '7.4'
           - '8.0'
           - '8.1'
+          - '8.2'
         include:
           - php-versions: '7.0'
             composer-flags: '--prefer-lowest'
@@ -61,7 +62,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
       - name: Run mutation tests
-        if: ${{ matrix.php-versions == 8.1 && matrix.operating-system == 'ubuntu-latest' }}
+        if: ${{ matrix.php-versions == 8.2 && matrix.operating-system == 'ubuntu-latest' }}
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
         run: |
@@ -69,7 +70,7 @@ jobs:
           composer req infection/infection -W
           vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=100 -s -j4
       - name: Run phpstan
-        if: ${{ matrix.php-versions == 8.1 && matrix.operating-system == 'ubuntu-latest' }}
+        if: ${{ matrix.php-versions == 8.2 && matrix.operating-system == 'ubuntu-latest' }}
         run: |
           composer req phpstan/phpstan
           vendor/bin/phpstan

--- a/src/Url/GitGenerator.php
+++ b/src/Url/GitGenerator.php
@@ -6,6 +6,9 @@ use Composer\Package\PackageInterface;
 
 abstract class GitGenerator implements UrlGenerator
 {
+    const REFERENCE_LENGTH = 40;
+    const SHORT_REFERENCE_LENGTH = 7;
+
     /**
      * {@inheritdoc}
      */
@@ -25,8 +28,8 @@ abstract class GitGenerator implements UrlGenerator
 
         $reference = $package->getSourceReference();
 
-        if (40 === \strlen($reference)) {
-            return \substr($reference, 0, 7);
+        if (self::REFERENCE_LENGTH === \strlen($reference)) {
+            return \substr($reference, 0, self::SHORT_REFERENCE_LENGTH);
         }
 
         return $reference;
@@ -62,7 +65,7 @@ abstract class GitGenerator implements UrlGenerator
     protected function getRepositoryUrl(PackageInterface $package)
     {
         $httpsUrl = preg_replace(
-            "/^git@({$this->getQuotedDomain()}):(.+)\/([^\/]+)(\.git)?$/",
+            "/^git@(?:git\.)?({$this->getQuotedDomain()}):(.+)\/([^\/]+)(\.git)?$/",
             'https://$1/$2/$3',
             $package->getSourceUrl()
         );

--- a/tests/Integration/DiffCommandTest.php
+++ b/tests/Integration/DiffCommandTest.php
@@ -7,6 +7,7 @@ use Composer\Console\Application;
 use Composer\Factory;
 use Composer\IO\IOInterface;
 use Composer\IO\NullIO;
+use Composer\Package\Package;
 use Composer\Plugin\PluginManager;
 use IonBazan\ComposerDiff\Command\DiffCommand;
 use IonBazan\ComposerDiff\PackageDiff;
@@ -46,11 +47,13 @@ class DiffCommandTest extends TestCase
         $app = new ComposerApplication();
         $app->setIO(new NullIO()); // For Composer v1
         $app->setAutoExit(false);
-        $composer = Factory::create($app->getIO(), null, true);
+        $plugin = $this->getPluginPackage();
+        $config = array('allow-plugins' => array($plugin->getName() => true));
+        $composer = Factory::create($app->getIO(), array('config' => $config), true);
         $app->setComposer($composer);
         $pm = new PluginManager($app->getIO(), $composer);
         $composer->setPluginManager($pm);
-        $pm->registerPackage($composer->getPackage(), true);
+        $pm->registerPackage($plugin, true);
         $tester = new ApplicationTester($app);
         $result = $tester->run($input, array('verbosity' => Output::VERBOSITY_VERY_VERBOSE));
         $this->assertSame($expectedOutput, $tester->getDisplay());
@@ -231,6 +234,17 @@ OUTPUT
                 ),
             ),
         );
+    }
+
+    /**
+     * @return Package
+     */
+    private function getPluginPackage()
+    {
+        $plugin = new Package('test-plugin-package', '1.0', '1.0');
+        $plugin->setExtra(array('class' => 'IonBazan\ComposerDiff\Composer\Plugin'));
+
+        return $plugin;
     }
 }
 


### PR DESCRIPTION
This PR fixes the test failure introduced when upgrading to Composer v2.3.9 or higher due to more strict behaviour during plugin registration (see https://github.com/composer/composer/releases/tag/2.3.9).