### PR TITLE
Symfony 7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         include:
           - php-versions: '5.3'
             dependencies: 'lowest'
@@ -38,7 +39,7 @@ jobs:
             operating-system: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2
         with:
@@ -57,7 +58,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
       - name: Run mutation tests
-        if: ${{ matrix.php-versions == 8.2 && matrix.operating-system == 'ubuntu-latest' }}
+        if: ${{ matrix.php-versions == 8.3 && matrix.operating-system == 'ubuntu-latest' }}
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
         run: |
@@ -65,7 +66,7 @@ jobs:
           composer req infection/infection -W
           vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=100 -s -j4
       - name: Run phpstan
-        if: ${{ matrix.php-versions == 8.2 && matrix.operating-system == 'ubuntu-latest' }}
+        if: ${{ matrix.php-versions == 8.3 && matrix.operating-system == 'ubuntu-latest' }}
         run: |
           composer req phpstan/phpstan
           vendor/bin/phpstan

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     },
     "require-dev": {
         "composer/composer": "^1.1 || ^2.0",
-        "symfony/console": "^2.3 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0"
+        "symfony/console": "^2.3 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0 || ^7.0"
     },
     "suggest": {
         "composer/composer": "To use the binary without composer runtime",

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -2,6 +2,9 @@
     "source": {
         "directories": [
             "src"
+        ],
+        "excludes": [
+            "src/Command/BaseNotTypedCommand.php"
         ]
     },
     "logs": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,5 @@ parameters:
         - src
     checkGenericClassInNonGenericObjectType: true
     checkMissingIterableValueType: true
+    bootstrapFiles:
+        - src/Command/DiffCommand.php # contains class alias

--- a/src/Command/BaseNotTypedCommand.php
+++ b/src/Command/BaseNotTypedCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Command;
+
+use Composer\Command\BaseCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * This class contains a non-typed version of execute() method (for PHP 5).
+ */
+abstract class BaseNotTypedCommand extends BaseCommand
+{
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        return $this->handle($input, $output);
+    }
+
+    /**
+     * @return int
+     */
+    abstract protected function handle(InputInterface $input, OutputInterface $output);
+}

--- a/src/Command/BaseTypedCommand.php
+++ b/src/Command/BaseTypedCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Command;
+
+use Composer\Command\BaseCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * This class contains a typed version of execute() method (PHP 7+).
+ */
+abstract class BaseTypedCommand extends BaseCommand
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return $this->handle($input, $output);
+    }
+
+    /**
+     * @return int
+     */
+    abstract protected function handle(InputInterface $input, OutputInterface $output);
+}

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -2,7 +2,6 @@
 
 namespace IonBazan\ComposerDiff\Command;
 
-use Composer\Command\BaseCommand;
 use IonBazan\ComposerDiff\Diff\DiffEntries;
 use IonBazan\ComposerDiff\Diff\DiffEntry;
 use IonBazan\ComposerDiff\Formatter\Formatter;
@@ -16,6 +15,17 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+
+/*
+ * This is a trick to maintain compatibility with both PHP 5 and 7 with Symfony 2.3 all the way to 7 with typed returns.
+ * This is only needed when using this package as a dependency with Symfony 7+, not when using as Composer plugin.
+ */
+class_alias(
+    PHP_VERSION_ID >= 70000
+        ? 'IonBazan\ComposerDiff\Command\BaseTypedCommand'
+        : 'IonBazan\ComposerDiff\Command\BaseNotTypedCommand',
+    'IonBazan\ComposerDiff\Command\BaseCommand'
+);
 
 class DiffCommand extends BaseCommand
 {
@@ -122,9 +132,9 @@ EOF
     }
 
     /**
-     * {@inheritdoc}
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function handle(InputInterface $input, OutputInterface $output)
     {
         $base = null !== $input->getArgument('base') ? $input->getArgument('base') : $input->getOption('base');
         $target = null !== $input->getArgument('target') ? $input->getArgument('target') : $input->getOption('target');
@@ -205,7 +215,7 @@ EOF
                 return new MarkdownListFormatter($output, $urlGenerators);
             case 'github':
                 return new GitHubFormatter($output, $urlGenerators);
-            // case 'mdtable':
+                // case 'mdtable':
             default:
                 return new MarkdownTableFormatter($output, $urlGenerators);
         }

--- a/tests/Command/DiffCommandTest.php
+++ b/tests/Command/DiffCommandTest.php
@@ -7,7 +7,6 @@ use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use IonBazan\ComposerDiff\Command\DiffCommand;
-use IonBazan\ComposerDiff\Tests\Integration\ComposerApplication;
 use IonBazan\ComposerDiff\Tests\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -21,7 +20,7 @@ class DiffCommandTest extends TestCase
     public function testItGeneratesReportInGivenFormat($expectedOutput, array $options)
     {
         $diff = $this->getMockBuilder('IonBazan\ComposerDiff\PackageDiff')->getMock();
-        $application = new ComposerApplication();
+        $application = $this->getComposerApplication();
         $command = new DiffCommand($diff, array('gitlab2.org'));
         $command->setApplication($application);
         $tester = new CommandTester($command);
@@ -53,7 +52,7 @@ class DiffCommandTest extends TestCase
     public function testStrictMode($exitCode, array $prodOperations, array $devOperations)
     {
         $diff = $this->getMockBuilder('IonBazan\ComposerDiff\PackageDiff')->getMock();
-        $application = new ComposerApplication();
+        $application = $this->getComposerApplication();
         $command = new DiffCommand($diff, array('gitlab2.org'));
         $command->setApplication($application);
         $tester = new CommandTester($command);
@@ -252,7 +251,7 @@ OUTPUT
                     'packages-dev' => array(
                         ),
                 ),
-                128
+                    128
                 ).PHP_EOL,
                 array(
                     '--no-dev' => null,

--- a/tests/Integration/DiffCommandTest.php
+++ b/tests/Integration/DiffCommandTest.php
@@ -2,10 +2,7 @@
 
 namespace IonBazan\ComposerDiff\Tests\Integration;
 
-use Composer\Composer;
-use Composer\Console\Application;
 use Composer\Factory;
-use Composer\IO\IOInterface;
 use Composer\IO\NullIO;
 use Composer\Package\Package;
 use Composer\Plugin\PluginManager;
@@ -25,9 +22,8 @@ class DiffCommandTest extends TestCase
      */
     public function testCommand($expectedOutput, array $input)
     {
-        $application = new ComposerApplication();
         $command = new DiffCommand(new PackageDiff());
-        $command->setApplication($application);
+        $command->setApplication($this->getComposerApplication());
         $tester = new CommandTester($command);
         $result = $tester->execute($input);
         $this->assertSame(0, $result);
@@ -44,7 +40,7 @@ class DiffCommandTest extends TestCase
     public function testComposerApplication($expectedOutput, array $input)
     {
         $input = array_merge(array('command' => 'diff'), $input);
-        $app = new ComposerApplication();
+        $app = $this->getComposerApplication();
         $app->setIO(new NullIO()); // For Composer v1
         $app->setAutoExit(false);
         $plugin = $this->getPluginPackage();
@@ -245,18 +241,5 @@ OUTPUT
         $plugin->setExtra(array('class' => 'IonBazan\ComposerDiff\Composer\Plugin'));
 
         return $plugin;
-    }
-}
-
-class ComposerApplication extends Application
-{
-    public function setIO(IOInterface $io)
-    {
-        $this->io = $io;
-    }
-
-    public function setComposer(Composer $composer)
-    {
-        $this->composer = $composer;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,8 @@ use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\Package\PackageInterface;
 use IonBazan\ComposerDiff\Diff\DiffEntries;
 use IonBazan\ComposerDiff\Diff\DiffEntry;
+use IonBazan\ComposerDiff\Tests\Util\ComposerApplication;
+use IonBazan\ComposerDiff\Tests\Util\TypedComposerApplication;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
@@ -72,5 +74,13 @@ abstract class TestCase extends BaseTestCase
         return new DiffEntries(array_map(function (OperationInterface $operation) {
             return new DiffEntry($operation);
         }, $operations));
+    }
+
+    /**
+     * @return ComposerApplication|TypedComposerApplication
+     */
+    protected function getComposerApplication()
+    {
+        return PHP_VERSION_ID >= 70000 ? new TypedComposerApplication() : new ComposerApplication();
     }
 }

--- a/tests/Util/ComposerApplication.php
+++ b/tests/Util/ComposerApplication.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Tests\Util;
+
+use Composer\Composer;
+use Composer\Console\Application;
+use Composer\IO\IOInterface;
+
+class ComposerApplication extends Application
+{
+    public function setIO(IOInterface $io)
+    {
+        $this->io = $io;
+    }
+
+    public function setComposer(Composer $composer)
+    {
+        $this->composer = $composer;
+    }
+
+    protected function getDefaultCommands()
+    {
+        return array();
+    }
+}

--- a/tests/Util/TypedComposerApplication.php
+++ b/tests/Util/TypedComposerApplication.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Tests\Util;
+
+use Composer\Composer;
+use Composer\Console\Application;
+use Composer\IO\IOInterface;
+
+class TypedComposerApplication extends Application
+{
+    public function setIO(IOInterface $io)
+    {
+        $this->io = $io;
+    }
+
+    public function setComposer(Composer $composer)
+    {
+        $this->composer = $composer;
+    }
+
+    protected function getDefaultCommands(): array
+    {
+        return array();
+    }
+}


### PR DESCRIPTION
As Symfony 7 adds return types to Commands which is a breaking change. To mitigate this, I did some hacks in order to maintain compatibility with both PHP 5.3 and older versions of Symfony by adding two base command variants and a conditional alias 🤮 

**Note: This only affects people using this library as a binary (`vendor/bin/composer-diff`) in a project where `composer/composer` and `symfony/console` are installed as dependencies. You can still use it as a Composer plugin (`composer diff`) with any version of Symfony without upgrading.**

Doesn't look nice but works like a charm (see tests)