### PR TITLE
Adding WordPress Package Link Generator

### DIFF
--- a/docs/url-generators.md
+++ b/docs/url-generators.md
@@ -6,6 +6,7 @@ URL generators are used to generate URLs for the packages listed in a diff:
 - `GitLabGenerator`: Generates URLs for GitLab repositories. Supports custom domains.
 - `BitbucketGenerator`: Generates URLs for Bitbucket repositories.
 - `DrupalGenerator`: Generates URLs for Drupal packages.
+- `WordPress`: Generates URLs for WordPress plugins and themes (via [WordPress Packagist](https://wpackagist.org/)).
 
 They are chosen automatically based on the package URL or other conditions specified in `supportsPackage()` method.
 

--- a/src/Url/GeneratorContainer.php
+++ b/src/Url/GeneratorContainer.php
@@ -21,6 +21,7 @@ class GeneratorContainer implements UrlGenerator
             new GithubGenerator(),
             new BitBucketGenerator(),
             new GitlabGenerator(),
+            new WordPressGenerator(),
         );
 
         foreach ($gitlabDomains as $domain) {

--- a/src/Url/WordPressGenerator.php
+++ b/src/Url/WordPressGenerator.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Url;
+
+use Composer\Package\PackageInterface;
+
+class WordPressGenerator implements UrlGenerator
+{
+    /**
+     * Determines if the generator supports the given package.
+     *
+     * @return bool
+     */
+    public function supportsPackage(PackageInterface $package)
+    {
+        return 0 === strpos($package->getName(), 'wpackagist-plugin/') || 0 === strpos($package->getName(), 'wpackagist-theme/');
+    }
+
+    /**
+     * Generates a compare URL for two versions of the same package.
+     *
+     * @return string|null
+     */
+    public function getCompareUrl(PackageInterface $initialPackage, PackageInterface $targetPackage)
+    {
+        return null;
+    }
+
+    /**
+     * Generates URL for viewing a release or commit of a package.
+     *
+     * @return string|null
+     */
+    public function getReleaseUrl(PackageInterface $package)
+    {
+        return null;
+    }
+
+    /**
+     * Generates URL for viewing the project page of a package (usually repository root).
+     *
+     * @return string|null
+     */
+    public function getProjectUrl(PackageInterface $package)
+    {
+        $type = $this->getPackageType($package);
+
+        if (null === $type) {
+            return null;
+        }
+
+        return sprintf('https://wordpress.org/%ss/%s', $type, $this->getPackageSlug($package));
+    }
+
+    /**
+     * @return string|null
+     */
+    protected function getPackageType(PackageInterface $package)
+    {
+        [$type] = explode('/', $package->getName(), 2);
+
+        return 0 === strpos($type, 'wpackagist-') ? substr($type, 11) : null;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getPackageSlug(PackageInterface $package)
+    {
+        [, $slug] = explode('/', $package->getName(), 2);
+
+        return $slug;
+    }
+}

--- a/src/Url/WordPressGenerator.php
+++ b/src/Url/WordPressGenerator.php
@@ -7,19 +7,15 @@ use Composer\Package\PackageInterface;
 class WordPressGenerator implements UrlGenerator
 {
     /**
-     * Determines if the generator supports the given package.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function supportsPackage(PackageInterface $package)
     {
-        return 0 === strpos($package->getName(), 'wpackagist-plugin/') || 0 === strpos($package->getName(), 'wpackagist-theme/');
+        return (bool) preg_match('#^wpackagist-(plugin|theme)/#', $package->getName());
     }
 
     /**
-     * Generates a compare URL for two versions of the same package.
-     *
-     * @return string|null
+     * {@inheritdoc}
      */
     public function getCompareUrl(PackageInterface $initialPackage, PackageInterface $targetPackage)
     {
@@ -27,9 +23,7 @@ class WordPressGenerator implements UrlGenerator
     }
 
     /**
-     * Generates URL for viewing a release or commit of a package.
-     *
-     * @return string|null
+     * {@inheritdoc}
      */
     public function getReleaseUrl(PackageInterface $package)
     {
@@ -37,38 +31,18 @@ class WordPressGenerator implements UrlGenerator
     }
 
     /**
-     * Generates URL for viewing the project page of a package (usually repository root).
-     *
-     * @return string|null
+     * {@inheritdoc}
      */
     public function getProjectUrl(PackageInterface $package)
     {
-        $type = $this->getPackageType($package);
+        preg_match('#wpackagist-(plugin|theme)/(.+)#', $package->getName(), $matches);
 
-        if (null === $type) {
+        if (empty($matches)) {
             return null;
         }
 
-        return sprintf('https://wordpress.org/%ss/%s', $type, $this->getPackageSlug($package));
-    }
+        list (, $type, $slug) = $matches;
 
-    /**
-     * @return string|null
-     */
-    protected function getPackageType(PackageInterface $package)
-    {
-        [$type] = explode('/', $package->getName(), 2);
-
-        return 0 === strpos($type, 'wpackagist-') ? substr($type, 11) : null;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getPackageSlug(PackageInterface $package)
-    {
-        [, $slug] = explode('/', $package->getName(), 2);
-
-        return $slug;
+        return sprintf('https://wordpress.org/%ss/%s', $type, $slug);
     }
 }

--- a/tests/Url/WordPressGeneratorTest.php
+++ b/tests/Url/WordPressGeneratorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Tests\Url;
+
+use Composer\Package\PackageInterface;
+use IonBazan\ComposerDiff\Url\WordPressGenerator;
+
+class WordPressGeneratorTest extends GeneratorTest
+{
+    public function releaseUrlProvider()
+    {
+        return array(
+            'plugin' => array(
+                $this->getPackageWithSource('wpackagist-plugin/jetpack', '13.1', 'https://plugins.svn.wordpress.org/jetpack/', '13.1'),
+                null,
+            ),
+            'theme' => array(
+                $this->getPackageWithSource('wpackagist-theme/twentytwenty', '1.7', 'https://themes.svn.wordpress.org/twentytwenty/', '1.7'),
+                null,
+            ),
+        );
+    }
+
+    public function projectUrlProvider()
+    {
+        return array(
+            'plugin' => array(
+                $this->getPackageWithSource('wpackagist-plugin/jetpack', '13.1', 'https://plugins.svn.wordpress.org/jetpack/', '13.1'),
+                'https://wordpress.org/plugins/jetpack',
+            ),
+            'theme' => array(
+                $this->getPackageWithSource('wpackagist-theme/twentytwenty', '1.7', 'https://themes.svn.wordpress.org/twentytwenty/', '1.7'),
+                'https://wordpress.org/themes/twentytwenty',
+            ),
+        );
+    }
+
+    public function compareUrlProvider()
+    {
+        return array(
+            'plugin' => array(
+                $this->getPackageWithSource('wpackagist-plugin/jetpack', '13.1', 'https://plugins.svn.wordpress.org/jetpack/', '13.1'),
+                $this->getPackageWithSource('wpackagist-plugin/jetpack', '13.2', 'https://plugins.svn.wordpress.org/jetpack/', '13.2'),
+                null,
+            ),
+            'theme' => array(
+                $this->getPackageWithSource('wpackagist-theme/twentytwenty', '1.7', 'https://themes.svn.wordpress.org/twentytwenty/', '1.7'),
+                $this->getPackageWithSource('wpackagist-theme/twentytwenty', '1.8', 'https://themes.svn.wordpress.org/twentytwenty/', '1.8'),
+                null,
+            ),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGenerator()
+    {
+        return new WordPressGenerator();
+    }
+}

--- a/tests/Url/WordPressGeneratorTest.php
+++ b/tests/Url/WordPressGeneratorTest.php
@@ -6,6 +6,16 @@ use IonBazan\ComposerDiff\Url\WordPressGenerator;
 
 class WordPressGeneratorTest extends GeneratorTest
 {
+    public function testItSupportsOnlyWpackagistPackages()
+    {
+        $generator = $this->getGenerator();
+
+        $this->assertFalse($generator->supportsPackage($this->getPackage('acme/package', '3.12.1')));
+        $this->assertTrue($generator->supportsPackage($this->getPackage('wpackagist-plugin/my-plugin', '3.12.1')));
+        $this->assertTrue($generator->supportsPackage($this->getPackage('wpackagist-theme/my-theme', '3.12.1')));
+        $this->assertFalse($generator->supportsPackage($this->getPackage('acme-wpackagist-theme/my-theme', '3.12.1')));
+    }
+
     public function releaseUrlProvider()
     {
         return array(

--- a/tests/Url/WordPressGeneratorTest.php
+++ b/tests/Url/WordPressGeneratorTest.php
@@ -2,7 +2,6 @@
 
 namespace IonBazan\ComposerDiff\Tests\Url;
 
-use Composer\Package\PackageInterface;
 use IonBazan\ComposerDiff\Url\WordPressGenerator;
 
 class WordPressGeneratorTest extends GeneratorTest


### PR DESCRIPTION
Adds WordPress plugin/theme link generation to the package name via [WordPress Packagist](https://wpackagist.org/).

Example:

```
| Prod Packages                                                      | Operation | Base | Target | Link |
|--------------------------------------------------------------------|-----------|------|--------|------|
| [wpackagist-plugin/jetpack](https://wordpress.org/plugins/jetpack) | Upgraded  | 13.1 | 13.9   |      |
```