### PR TITLE
Return package home URL when no generator supports it

### DIFF
--- a/src/Url/GeneratorContainer.php
+++ b/src/Url/GeneratorContainer.php
@@ -2,6 +2,7 @@
 
 namespace IonBazan\ComposerDiff\Url;
 
+use Composer\Package\CompletePackage;
 use Composer\Package\PackageInterface;
 
 class GeneratorContainer implements UrlGenerator
@@ -69,10 +70,14 @@ class GeneratorContainer implements UrlGenerator
 
     public function getProjectUrl(PackageInterface $package)
     {
-        if (!$generator = $this->get($package)) {
-            return null;
+        if ($generator = $this->get($package)) {
+            return $generator->getProjectUrl($package);
         }
 
-        return $generator->getProjectUrl($package);
+        if ($package instanceof CompletePackage) {
+            return $package->getHomepage();
+        }
+
+        return null;
     }
 }

--- a/tests/Url/GeneratorContainerTest.php
+++ b/tests/Url/GeneratorContainerTest.php
@@ -2,6 +2,7 @@
 
 namespace IonBazan\ComposerDiff\Tests\Url;
 
+use Composer\Package\CompletePackage;
 use IonBazan\ComposerDiff\Tests\TestCase;
 use IonBazan\ComposerDiff\Url\GeneratorContainer;
 
@@ -29,5 +30,17 @@ class GeneratorContainerTest extends TestCase
         $generator = new GeneratorContainer(array());
         self::assertTrue($generator->supportsPackage($this->getPackageWithSource('acme/package', '3.12.0', 'https://bitbucket.org/acme/package.git')));
         self::assertFalse($generator->supportsPackage($this->getPackageWithSource('acme/package', '3.12.0', 'https://non-existent.org/acme/package.git')));
+    }
+
+    public function testItReturnsHomepageForProjectUrlWhenNoGeneratorSupportsPackage()
+    {
+        $generator = new GeneratorContainer();
+        $package = new CompletePackage('acme/package', '3.12.0', '3.12.0');
+        $package->setHomepage('https://acme.com');
+
+        self::assertSame('https://acme.com', $generator->getProjectUrl($package));
+
+        $package->setHomepage(null);
+        self::assertNull($generator->getProjectUrl($package));
     }
 }


### PR DESCRIPTION
When no `UrlGenerator` supports a package, `getProjectUrl()` returns `null`. This change displays package's home page instead.

Replaces #36 