### PR TITLE
[Feature][BC break] Allow creating diffs from array and shift URL generation to DiffEntry

### DIFF
--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -147,8 +147,10 @@ EOF
         $this->gitlabDomains = array_merge($this->gitlabDomains, $input->getOption('gitlab-domains'));
 
         $urlGenerators = new GeneratorContainer($this->gitlabDomains);
-        $formatters = new FormatterContainer($output, $urlGenerators);
+        $formatters = new FormatterContainer($output);
         $formatter = $formatters->getFormatter($input->getOption('format'));
+
+        $this->packageDiff->setUrlGenerator($urlGenerators);
 
         $prodOperations = new DiffEntries(array());
         $devOperations = new DiffEntries(array());

--- a/src/Diff/DiffEntry.php
+++ b/src/Diff/DiffEntry.php
@@ -6,7 +6,9 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
+use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;
+use IonBazan\ComposerDiff\Url\UrlGenerator;
 
 class DiffEntry
 {
@@ -25,14 +27,25 @@ class DiffEntry
     /** @var string */
     private $type;
 
+    /** @var string|null */
+    private $compareUrl;
+
+    /** @var string|null */
+    private $projectUrl;
+
     /**
-     * @param bool $direct
+     * @param UrlGenerator|null $urlGenerator
+     * @param bool              $direct
      */
-    public function __construct(OperationInterface $operation, $direct = false)
+    public function __construct(OperationInterface $operation, $urlGenerator = null, $direct = false)
     {
         $this->operation = $operation;
         $this->direct = $direct;
         $this->type = $this->determineType();
+
+        if ($urlGenerator instanceof UrlGenerator) {
+            $this->setUrls($urlGenerator);
+        }
     }
 
     /**
@@ -100,7 +113,15 @@ class DiffEntry
     }
 
     /**
-     * @return PackageInterface|null
+     * @return string
+     */
+    public function getPackageName()
+    {
+        return $this->getPackage()->getName();
+    }
+
+    /**
+     * @return PackageInterface
      */
     public function getPackage()
     {
@@ -114,7 +135,114 @@ class DiffEntry
             return $operation->getPackage();
         }
 
+        throw new \InvalidArgumentException('Invalid operation');
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLicenses()
+    {
+        $package = $this->getPackage();
+
+        if (!$package instanceof CompletePackageInterface) {
+            return array();
+        }
+
+        return $package->getLicense();
+    }
+
+    /**
+     * @return array{
+     *     name: string,
+     *     direct: bool,
+     *     operation: string,
+     *     version_base: string|null,
+     *     version_target: string|null,
+     *     licenses: string[],
+     *     compare: string|null,
+     *     link: string|null,
+     * }
+     */
+    public function toArray()
+    {
+        return array(
+            'name' => $this->getPackageName(),
+            'direct' => $this->isDirect(),
+            'operation' => $this->getType(),
+            'version_base' => $this->getBaseVersion(),
+            'version_target' => $this->getTargetVersion(),
+            'licenses' => $this->getLicenses(),
+            'compare' => $this->getUrl(),
+            'link' => $this->getProjectUrl(),
+        );
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBaseVersion()
+    {
+        if ($this->operation instanceof UpdateOperation) {
+            return $this->operation->getInitialPackage()->getFullPrettyVersion();
+        }
+
+        if ($this->operation instanceof UninstallOperation) {
+            return $this->operation->getPackage()->getFullPrettyVersion();
+        }
+
         return null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTargetVersion()
+    {
+        if ($this->operation instanceof UpdateOperation) {
+            return $this->operation->getTargetPackage()->getFullPrettyVersion();
+        }
+
+        if ($this->operation instanceof InstallOperation) {
+            return $this->operation->getPackage()->getFullPrettyVersion();
+        }
+
+        return null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUrl()
+    {
+        return $this->compareUrl;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getProjectUrl()
+    {
+        return $this->projectUrl;
+    }
+
+    /**
+     * @return void
+     */
+    private function setUrls(UrlGenerator $generator)
+    {
+        $package = $this->getPackage();
+        $this->projectUrl = $generator->getProjectUrl($package);
+
+        $operation = $this->getOperation();
+
+        if ($operation instanceof UpdateOperation) {
+            $this->compareUrl = $generator->getCompareUrl($operation->getInitialPackage(), $operation->getTargetPackage());
+
+            return;
+        }
+
+        $this->compareUrl = $generator->getReleaseUrl($package);
     }
 
     /**

--- a/src/Formatter/AbstractFormatter.php
+++ b/src/Formatter/AbstractFormatter.php
@@ -2,13 +2,7 @@
 
 namespace IonBazan\ComposerDiff\Formatter;
 
-use Composer\DependencyResolver\Operation\InstallOperation;
-use Composer\DependencyResolver\Operation\OperationInterface;
-use Composer\DependencyResolver\Operation\UninstallOperation;
-use Composer\DependencyResolver\Operation\UpdateOperation;
-use Composer\Package\CompletePackageInterface;
 use IonBazan\ComposerDiff\Diff\DiffEntry;
-use IonBazan\ComposerDiff\Url\GeneratorContainer;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractFormatter implements Formatter
@@ -18,71 +12,9 @@ abstract class AbstractFormatter implements Formatter
      */
     protected $output;
 
-    /**
-     * @var GeneratorContainer
-     */
-    protected $generators;
-
-    public function __construct(OutputInterface $output, GeneratorContainer $generators)
+    public function __construct(OutputInterface $output)
     {
         $this->output = $output;
-        $this->generators = $generators;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getUrl(DiffEntry $entry)
-    {
-        $operation = $entry->getOperation();
-
-        if ($operation instanceof UpdateOperation) {
-            return $this->generators->getCompareUrl($operation->getInitialPackage(), $operation->getTargetPackage());
-        }
-
-        if ($operation instanceof InstallOperation || $operation instanceof UninstallOperation) {
-            return $this->generators->getReleaseUrl($operation->getPackage());
-        }
-
-        return null;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getLicenses(DiffEntry $entry)
-    {
-        if (!$entry->getPackage() instanceof CompletePackageInterface) {
-            return null;
-        }
-
-        $licenses = $entry->getPackage()->getLicense();
-
-        if (empty($licenses)) {
-            return null;
-        }
-
-        return implode(', ', $licenses);
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getProjectUrl(OperationInterface $operation)
-    {
-        if ($operation instanceof UpdateOperation) {
-            $package = $operation->getInitialPackage();
-        }
-
-        if ($operation instanceof InstallOperation || $operation instanceof UninstallOperation) {
-            $package = $operation->getPackage();
-        }
-
-        if (!isset($package)) {
-            return null;
-        }
-
-        return $this->generators->getProjectUrl($package);
     }
 
     /**
@@ -90,13 +22,7 @@ abstract class AbstractFormatter implements Formatter
      */
     protected function getDecoratedPackageName(DiffEntry $entry)
     {
-        $package = $entry->getPackage();
-
-        if (null === $package) {
-            return '';
-        }
-
-        return $this->terminalLink($this->getProjectUrl($entry->getOperation()), $package->getName());
+        return $this->terminalLink($entry->getProjectUrl(), $entry->getPackageName());
     }
 
     /**

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -3,7 +3,6 @@
 namespace IonBazan\ComposerDiff\Formatter;
 
 use IonBazan\ComposerDiff\Diff\DiffEntries;
-use IonBazan\ComposerDiff\Diff\DiffEntry;
 
 interface Formatter
 {
@@ -23,14 +22,4 @@ interface Formatter
      * @return void
      */
     public function renderSingle(DiffEntries $entries, $title, $withUrls, $withLicenses);
-
-    /**
-     * @return string|null
-     */
-    public function getUrl(DiffEntry $entry);
-
-    /**
-     * @return string|null
-     */
-    public function getLicenses(DiffEntry $entry);
 }

--- a/src/Formatter/FormatterContainer.php
+++ b/src/Formatter/FormatterContainer.php
@@ -2,7 +2,6 @@
 
 namespace IonBazan\ComposerDiff\Formatter;
 
-use IonBazan\ComposerDiff\Url\GeneratorContainer;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class FormatterContainer
@@ -14,13 +13,13 @@ class FormatterContainer
      */
     private $formatters;
 
-    public function __construct(OutputInterface $output, GeneratorContainer $generators)
+    public function __construct(OutputInterface $output)
     {
         $this->formatters = array(
-            'mdtable' => new MarkdownTableFormatter($output, $generators),
-            'mdlist' => new MarkdownListFormatter($output, $generators),
-            'github' => new GitHubFormatter($output, $generators),
-            'json' => new JsonFormatter($output, $generators),
+            'mdtable' => new MarkdownTableFormatter($output),
+            'mdlist' => new MarkdownListFormatter($output),
+            'github' => new GitHubFormatter($output),
+            'json' => new JsonFormatter($output),
         );
     }
 

--- a/src/Formatter/JsonFormatter.php
+++ b/src/Formatter/JsonFormatter.php
@@ -2,9 +2,6 @@
 
 namespace IonBazan\ComposerDiff\Formatter;
 
-use Composer\DependencyResolver\Operation\InstallOperation;
-use Composer\DependencyResolver\Operation\UninstallOperation;
-use Composer\DependencyResolver\Operation\UpdateOperation;
 use IonBazan\ComposerDiff\Diff\DiffEntries;
 use IonBazan\ComposerDiff\Diff\DiffEntry;
 
@@ -50,61 +47,21 @@ class JsonFormatter extends AbstractFormatter
     {
         $rows = array();
 
+        /** @var DiffEntry $entry */
         foreach ($entries as $entry) {
-            $row = $this->transformEntry($entry);
+            $row = $entry->toArray();
 
-            if ($withUrls) {
-                $row['compare'] = $this->getUrl($entry);
-                $row['link'] = $this->getProjectUrl($entry->getOperation());
+            if (!$withUrls) {
+                unset($row['compare'], $row['link']);
             }
 
-            if ($withLicenses) {
-                $row['license'] = $this->getLicenses($entry);
+            if (!$withLicenses) {
+                unset($row['licenses']);
             }
 
             $rows[$row['name']] = $row;
         }
 
         return $rows;
-    }
-
-    /**
-     * @return array<string, string|bool|null>
-     */
-    private function transformEntry(DiffEntry $entry)
-    {
-        $operation = $entry->getOperation();
-
-        if ($operation instanceof InstallOperation) {
-            return array(
-                'name' => $operation->getPackage()->getName(),
-                'direct' => $entry->isDirect(),
-                'operation' => $entry->getType(),
-                'version_base' => null,
-                'version_target' => $operation->getPackage()->getFullPrettyVersion(),
-            );
-        }
-
-        if ($operation instanceof UpdateOperation) {
-            return array(
-                'name' => $operation->getInitialPackage()->getName(),
-                'direct' => $entry->isDirect(),
-                'operation' => $entry->getType(),
-                'version_base' => $operation->getInitialPackage()->getFullPrettyVersion(),
-                'version_target' => $operation->getTargetPackage()->getFullPrettyVersion(),
-            );
-        }
-
-        if ($operation instanceof UninstallOperation) {
-            return array(
-                'name' => $operation->getPackage()->getName(),
-                'direct' => $entry->isDirect(),
-                'operation' => $entry->getType(),
-                'version_base' => $operation->getPackage()->getFullPrettyVersion(),
-                'version_target' => null,
-            );
-        }
-
-        throw new \InvalidArgumentException('Invalid operation');
     }
 }

--- a/tests/Diff/DiffEntryTest.php
+++ b/tests/Diff/DiffEntryTest.php
@@ -23,6 +23,106 @@ class DiffEntryTest extends TestCase
         $this->assertTrue($entry->{'is'.ucfirst($expectedType)}());
     }
 
+    public function testToArray()
+    {
+        $operation = new InstallOperation($this->getPackage('a/package-1', '1.0.0'));
+        $entry = new DiffEntry($operation);
+        $this->assertSame(array(
+            'name' => 'a/package-1',
+            'direct' => false,
+            'operation' => 'install',
+            'version_base' => null,
+            'version_target' => '1.0.0',
+            'licenses' => array(),
+            'compare' => null,
+            'link' => null,
+        ), $entry->toArray());
+    }
+
+    public function testIsDirect()
+    {
+        $operation = new InstallOperation($this->getPackage('a/package-1', '1.0.0'));
+        $entry = new DiffEntry($operation, null, true);
+        $this->assertTrue($entry->isDirect());
+
+        $entry = new DiffEntry($operation, null, false);
+        $this->assertFalse($entry->isDirect());
+    }
+
+    public function testGetPackage()
+    {
+        $package = $this->getPackage('a/package-1', '1.0.0');
+        $operation = new InstallOperation($package);
+        $entry = new DiffEntry($operation, null, true);
+        $this->assertSame($package, $entry->getPackage());
+    }
+
+    /**
+     * @param string $expectedUrl
+     *
+     * @dataProvider operationUrlProvider
+     */
+    public function testUrls($expectedUrl, OperationInterface $operation)
+    {
+        $urlGenerator = $this->getMockBuilder('IonBazan\ComposerDiff\Url\UrlGenerator')->getMock();
+        $urlGenerator->method('getCompareUrl')->willReturn('compare');
+        $urlGenerator->method('getProjectUrl')->willReturn('project');
+        $urlGenerator->method('getReleaseUrl')->willReturn('release');
+
+        $entry = new DiffEntry($operation, $urlGenerator);
+        $this->assertSame($expectedUrl, $entry->getUrl());
+        $this->assertSame('project', $entry->getProjectUrl());
+    }
+
+    public function testGetUrlReturnsNullForInvalidOperation()
+    {
+        $operation = $this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock();
+        $this->setExpectedException('InvalidArgumentException', 'Invalid operation');
+        new DiffEntry($operation, $this->getMockBuilder('IonBazan\ComposerDiff\Url\UrlGenerator')->getMock());
+    }
+
+    public function testGetProjectUrlReturnsNullForInvalidOperation()
+    {
+        $operation = $this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock();
+        $this->setExpectedException('InvalidArgumentException', 'Invalid operation');
+        new DiffEntry($operation, $this->getMockBuilder('IonBazan\ComposerDiff\Url\UrlGenerator')->getMock());
+    }
+
+    public function testCreateWithoutUrlGenerators()
+    {
+        $operation = $this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock();
+        $entry = new DiffEntry($operation);
+
+        $this->assertNull($entry->getUrl());
+        $this->assertNull($entry->getProjectUrl());
+    }
+
+    public function operationUrlProvider()
+    {
+        return array(
+            'Install shows release URL' => array(
+                'release',
+                new InstallOperation($this->getPackage('a/package-1', '1.0.0')),
+            ),
+            'Remove shows release URL' => array(
+                'release',
+                new UninstallOperation($this->getPackage('a/package-1', '1.0.0')),
+            ),
+            'Upgrade shows compare URL' => array(
+                'compare',
+                new UpdateOperation($this->getPackage('a/package-1', '1.0.0'), $this->getPackage('a/package-1', '2.0.0')),
+            ),
+            'Downgrade shows compare URL' => array(
+                'compare',
+                new UpdateOperation($this->getPackage('a/package-1', '2.0.0'), $this->getPackage('a/package-1', '1.0.0')),
+            ),
+            'Change shows compare URL' => array(
+                'compare',
+                new UpdateOperation($this->getPackage('a/package-1', 'dev-master', 'dev-master 1234567'), $this->getPackage('a/package-1', '1.0.0')),
+            ),
+        );
+    }
+
     public function operationTypeProvider()
     {
         return array(

--- a/tests/Formatter/FormatterTest.php
+++ b/tests/Formatter/FormatterTest.php
@@ -6,13 +6,9 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\OperationInterface;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
-use Composer\Package\PackageInterface;
 use IonBazan\ComposerDiff\Diff\DiffEntries;
-use IonBazan\ComposerDiff\Diff\DiffEntry;
 use IonBazan\ComposerDiff\Formatter\Formatter;
 use IonBazan\ComposerDiff\Tests\TestCase;
-use IonBazan\ComposerDiff\Url\GeneratorContainer;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -21,25 +17,9 @@ abstract class FormatterTest extends TestCase
     public function testItNoopsWhenListIsEmpty()
     {
         $output = new StreamOutput(fopen('php://memory', 'wb', false));
-        $formatter = $this->getFormatter($output, $this->getGenerators());
+        $formatter = $this->getFormatter($output);
         $formatter->render(new DiffEntries(array()), new DiffEntries(array()), true, false);
         $this->assertSame(static::getEmptyOutput(), $this->getDisplay($output));
-    }
-
-    public function testGetUrlReturnsNullForInvalidOperation()
-    {
-        $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
-        $operation = $this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock();
-        $formatter = $this->getFormatter($output, $this->getGenerators());
-        $this->assertNull($formatter->getUrl(new DiffEntry($operation)));
-    }
-
-    public function testGetProjectUrlReturnsNullForInvalidOperation()
-    {
-        $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
-        $operation = $this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock();
-        $formatter = $this->getFormatter($output, $this->getGenerators());
-        $this->assertNull($formatter->getProjectUrl($operation));
     }
 
     /**
@@ -58,9 +38,9 @@ abstract class FormatterTest extends TestCase
     public function testItRendersTheListOfOperations($withUrls, $withLicenses, $decorated = false)
     {
         $output = new StreamOutput(fopen('php://memory', 'wb', false), OutputInterface::VERBOSITY_NORMAL, $decorated);
-        $this->getFormatter($output, $this->getGenerators())->render(
-            $this->getEntries($this->getSampleProdOperations()),
-            $this->getEntries($this->getSampleDevOperations()),
+        $this->getFormatter($output)->render(
+            $this->getEntries($this->getSampleProdOperations(), $this->getGenerators()),
+            $this->getEntries($this->getSampleDevOperations(), $this->getGenerators()),
             $withUrls,
             $withLicenses
         );
@@ -71,15 +51,15 @@ abstract class FormatterTest extends TestCase
     {
         $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
         $this->setExpectedException('InvalidArgumentException', 'Invalid operation');
-        $this->getFormatter($output, $this->getGenerators())->render($this->getEntries(array(
+        $this->getFormatter($output)->render($this->getEntries(array(
             $this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock(),
-        )), $this->getEntries(array()), false, false);
+        ), $this->getGenerators()), $this->getEntries(array(), $this->getGenerators()), false, false);
     }
 
     /**
      * @return Formatter
      */
-    abstract protected function getFormatter(OutputInterface $output, GeneratorContainer $generators);
+    abstract protected function getFormatter(OutputInterface $output);
 
     /**
      * @param bool $withUrls
@@ -114,38 +94,6 @@ abstract class FormatterTest extends TestCase
     protected function supportsLinks()
     {
         return method_exists('Symfony\Component\Console\Formatter\OutputFormatterStyle', 'setHref');
-    }
-
-    /**
-     * @return MockObject|GeneratorContainer
-     */
-    protected function getGenerators()
-    {
-        $generator = $this->getMockBuilder('IonBazan\ComposerDiff\Url\UrlGenerator')->getMock();
-        $generator->method('getCompareUrl')->willReturnCallback(function (PackageInterface $base, PackageInterface $target) {
-            return sprintf('https://example.com/c/%s..%s', $base->getVersion(), $target->getVersion());
-        });
-        $generator->method('getReleaseUrl')->willReturnCallback(function (PackageInterface $package) {
-            return sprintf('https://example.com/r/%s', $package->getVersion());
-        });
-        $generator->method('getProjectUrl')->willReturnCallback(function (PackageInterface $package) {
-            return sprintf('https://example.com/r/%s', $package->getName());
-        });
-
-        $generators = $this->getMockBuilder('IonBazan\ComposerDiff\Url\GeneratorContainer')
-            ->disableOriginalConstructor()
-            ->setMethods(array('get'))
-            ->getMock();
-        $generators->method('get')
-            ->willReturnCallback(function (PackageInterface $package) use ($generator) {
-                if ('php' === $package->getName() || false !== strpos($package->getName(), 'a/no-link')) {
-                    return null;
-                }
-
-                return $generator;
-            });
-
-        return $generators;
     }
 
     /**

--- a/tests/Formatter/GitHubFormatterTest.php
+++ b/tests/Formatter/GitHubFormatterTest.php
@@ -3,7 +3,6 @@
 namespace IonBazan\ComposerDiff\Tests\Formatter;
 
 use IonBazan\ComposerDiff\Formatter\GitHubFormatter;
-use IonBazan\ComposerDiff\Url\GeneratorContainer;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class GitHubFormatterTest extends FormatterTest
@@ -36,8 +35,8 @@ OUTPUT;
     /**
      * {@inheritdoc}
      */
-    protected function getFormatter(OutputInterface $output, GeneratorContainer $generators)
+    protected function getFormatter(OutputInterface $output)
     {
-        return new GitHubFormatter($output, $generators);
+        return new GitHubFormatter($output);
     }
 }

--- a/tests/Formatter/JsonFormatterTest.php
+++ b/tests/Formatter/JsonFormatterTest.php
@@ -6,7 +6,6 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use IonBazan\ComposerDiff\Formatter\JsonFormatter;
-use IonBazan\ComposerDiff\Url\GeneratorContainer;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -25,8 +24,8 @@ class JsonFormatterTest extends FormatterTest
             new UninstallOperation($this->getPackage('a/no-link-2', '0.1.1')),
         );
         $output = new StreamOutput(fopen('php://memory', 'wb', false));
-        $formatter = $this->getFormatter($output, $this->getGenerators());
-        $formatter->renderSingle($this->getEntries($sampleData), 'test', true, false);
+        $formatter = $this->getFormatter($output);
+        $formatter->renderSingle($this->getEntries($sampleData, $this->getGenerators()), 'test', true, false);
 
         $this->assertSame(self::formatOutput(array(
             'a/package-1' => array(
@@ -97,107 +96,7 @@ class JsonFormatterTest extends FormatterTest
 
     protected function getSampleOutput($withUrls, $withLicenses, $decorated)
     {
-        if ($withLicenses) {
-            $package4License = array('license' => 'MIT, BSD-3-Clause');
-            $noLink2License = array('license' => 'MIT');
-            $nullLicense = array('license' => null);
-        } else {
-            $package4License = array();
-            $noLink2License = array();
-            $nullLicense = array();
-        }
-
-        if ($withUrls) {
-            return self::formatOutput(array(
-                'packages' => array(
-                        'a/package-1' => array(
-                                'name' => 'a/package-1',
-                                'direct' => false,
-                                'operation' => 'install',
-                                'version_base' => null,
-                                'version_target' => '1.0.0',
-                                'compare' => 'https://example.com/r/1.0.0',
-                                'link' => 'https://example.com/r/a/package-1',
-                            ) + $nullLicense,
-                        'a/no-link-1' => array(
-                                'name' => 'a/no-link-1',
-                                'direct' => false,
-                                'operation' => 'install',
-                                'version_base' => null,
-                                'version_target' => '1.0.0',
-                                'compare' => null,
-                                'link' => null,
-                            ) + $nullLicense,
-                        'a/package-2' => array(
-                                'name' => 'a/package-2',
-                                'direct' => false,
-                                'operation' => 'upgrade',
-                                'version_base' => '1.0.0',
-                                'version_target' => '1.2.0',
-                                'compare' => 'https://example.com/c/1.0.0..1.2.0',
-                                'link' => 'https://example.com/r/a/package-2',
-                            ) + $nullLicense,
-                        'a/package-3' => array(
-                                'name' => 'a/package-3',
-                                'direct' => false,
-                                'operation' => 'downgrade',
-                                'version_base' => '2.0.0',
-                                'version_target' => '1.1.1',
-                                'compare' => 'https://example.com/c/2.0.0..1.1.1',
-                                'link' => 'https://example.com/r/a/package-3',
-                            ) + $nullLicense,
-                        'a/no-link-2' => array(
-                                'name' => 'a/no-link-2',
-                                'direct' => false,
-                                'operation' => 'downgrade',
-                                'version_base' => '2.0.0',
-                                'version_target' => '1.1.1',
-                                'compare' => null,
-                                'link' => null,
-                            ) + $nullLicense,
-                        'php' => array(
-                            'name' => 'php',
-                            'direct' => false,
-                            'operation' => 'change',
-                            'version_base' => '>=7.4.6',
-                            'version_target' => '^8.0',
-                            'compare' => null,
-                            'link' => null,
-                        ) + $nullLicense,
-                    ),
-                'packages-dev' => array(
-                        'a/package-5' => array(
-                                'name' => 'a/package-5',
-                                'direct' => false,
-                                'operation' => 'change',
-                                'version_base' => 'dev-master 1234567',
-                                'version_target' => '1.1.1',
-                                'compare' => 'https://example.com/c/dev-master..1.1.1',
-                                'link' => 'https://example.com/r/a/package-5',
-                            ) + $nullLicense,
-                        'a/package-4' => array(
-                                'name' => 'a/package-4',
-                                'direct' => false,
-                                'operation' => 'remove',
-                                'version_base' => '0.1.1',
-                                'version_target' => null,
-                                'compare' => 'https://example.com/r/0.1.1',
-                                'link' => 'https://example.com/r/a/package-4',
-                            ) + $package4License,
-                        'a/no-link-2' => array(
-                                'name' => 'a/no-link-2',
-                                'direct' => false,
-                                'operation' => 'remove',
-                                'version_base' => '0.1.1',
-                                'version_target' => null,
-                                'compare' => null,
-                                'link' => null,
-                            ) + $noLink2License,
-                    ),
-            ));
-        }
-
-        return self::formatOutput(array(
+        $packages = array(
             'packages' => array(
                 'a/package-1' => array(
                     'name' => 'a/package-1',
@@ -205,42 +104,60 @@ class JsonFormatterTest extends FormatterTest
                     'operation' => 'install',
                     'version_base' => null,
                     'version_target' => '1.0.0',
-                ) + $nullLicense,
+                    'licenses' => array(),
+                    'compare' => 'https://example.com/r/1.0.0',
+                    'link' => 'https://example.com/r/a/package-1',
+                ),
                 'a/no-link-1' => array(
                     'name' => 'a/no-link-1',
                     'direct' => false,
                     'operation' => 'install',
                     'version_base' => null,
                     'version_target' => '1.0.0',
-                ) + $nullLicense,
+                    'licenses' => array(),
+                    'compare' => null,
+                    'link' => null,
+                ),
                 'a/package-2' => array(
                     'name' => 'a/package-2',
                     'direct' => false,
                     'operation' => 'upgrade',
                     'version_base' => '1.0.0',
                     'version_target' => '1.2.0',
-                ) + $nullLicense,
+                    'licenses' => array(),
+                    'compare' => 'https://example.com/c/1.0.0..1.2.0',
+                    'link' => 'https://example.com/r/a/package-2',
+                ),
                 'a/package-3' => array(
                     'name' => 'a/package-3',
                     'direct' => false,
                     'operation' => 'downgrade',
                     'version_base' => '2.0.0',
                     'version_target' => '1.1.1',
-                ) + $nullLicense,
+                    'licenses' => array(),
+                    'compare' => 'https://example.com/c/2.0.0..1.1.1',
+                    'link' => 'https://example.com/r/a/package-3',
+                ),
                 'a/no-link-2' => array(
                     'name' => 'a/no-link-2',
                     'direct' => false,
                     'operation' => 'downgrade',
                     'version_base' => '2.0.0',
                     'version_target' => '1.1.1',
-                ) + $nullLicense,
+                    'licenses' => array(),
+                    'compare' => null,
+                    'link' => null,
+                ),
                 'php' => array(
                     'name' => 'php',
                     'direct' => false,
                     'operation' => 'change',
                     'version_base' => '>=7.4.6',
                     'version_target' => '^8.0',
-                ) + $nullLicense,
+                    'licenses' => array(),
+                    'compare' => null,
+                    'link' => null,
+                ),
             ),
             'packages-dev' => array(
                 'a/package-5' => array(
@@ -249,31 +166,60 @@ class JsonFormatterTest extends FormatterTest
                     'operation' => 'change',
                     'version_base' => 'dev-master 1234567',
                     'version_target' => '1.1.1',
-                ) + $nullLicense,
+                    'licenses' => array(),
+                    'compare' => 'https://example.com/c/dev-master..1.1.1',
+                    'link' => 'https://example.com/r/a/package-5',
+                ),
                 'a/package-4' => array(
                     'name' => 'a/package-4',
                     'direct' => false,
                     'operation' => 'remove',
                     'version_base' => '0.1.1',
                     'version_target' => null,
-                ) + $package4License,
+                    'licenses' => array('MIT', 'BSD-3-Clause'),
+                    'compare' => 'https://example.com/r/0.1.1',
+                    'link' => 'https://example.com/r/a/package-4',
+                ),
                 'a/no-link-2' => array(
                     'name' => 'a/no-link-2',
                     'direct' => false,
                     'operation' => 'remove',
                     'version_base' => '0.1.1',
                     'version_target' => null,
-                ) + $noLink2License,
+                    'licenses' => array('MIT'),
+                    'compare' => null,
+                    'link' => null,
+                ),
             ),
-        ));
+        );
+
+        foreach ($packages['packages'] as &$package) {
+            if (!$withLicenses) {
+                unset($package['licenses']);
+            }
+            if (!$withUrls) {
+                unset($package['compare'], $package['link']);
+            }
+        }
+
+        foreach ($packages['packages-dev'] as &$package) {
+            if (!$withLicenses) {
+                unset($package['licenses']);
+            }
+            if (!$withUrls) {
+                unset($package['compare'], $package['link']);
+            }
+        }
+
+        return self::formatOutput($packages);
     }
 
     /**
      * {@inheritdoc}
      */
-    protected function getFormatter(OutputInterface $output, GeneratorContainer $generators)
+    protected function getFormatter(OutputInterface $output)
     {
-        return new JsonFormatter($output, $generators);
+        return new JsonFormatter($output);
     }
 
     protected static function getEmptyOutput()

--- a/tests/Formatter/MarkdownListFormatterTest.php
+++ b/tests/Formatter/MarkdownListFormatterTest.php
@@ -3,7 +3,6 @@
 namespace IonBazan\ComposerDiff\Tests\Formatter;
 
 use IonBazan\ComposerDiff\Formatter\MarkdownListFormatter;
-use IonBazan\ComposerDiff\Url\GeneratorContainer;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class MarkdownListFormatterTest extends FormatterTest
@@ -112,8 +111,8 @@ OUTPUT;
     /**
      * {@inheritdoc}
      */
-    protected function getFormatter(OutputInterface $output, GeneratorContainer $generators)
+    protected function getFormatter(OutputInterface $output)
     {
-        return new MarkdownListFormatter($output, $generators);
+        return new MarkdownListFormatter($output);
     }
 }

--- a/tests/Formatter/MarkdownTableFormatterTest.php
+++ b/tests/Formatter/MarkdownTableFormatterTest.php
@@ -3,7 +3,6 @@
 namespace IonBazan\ComposerDiff\Tests\Formatter;
 
 use IonBazan\ComposerDiff\Formatter\MarkdownTableFormatter;
-use IonBazan\ComposerDiff\Url\GeneratorContainer;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class MarkdownTableFormatterTest extends FormatterTest
@@ -159,8 +158,8 @@ OUTPUT;
     /**
      * {@inheritdoc}
      */
-    protected function getFormatter(OutputInterface $output, GeneratorContainer $generators)
+    protected function getFormatter(OutputInterface $output)
     {
-        return new MarkdownTableFormatter($output, $generators);
+        return new MarkdownTableFormatter($output);
     }
 }


### PR DESCRIPTION
These changes are to make it easier to reuse this project as dependency as demonstrated in https://github.com/lyrixx/composer-diff. If you haven't checked it out yet, I strongly recommend you to do so - it's very useful if you don't have access to your PHP interpreter locally.

From user-perspective, there are no behavior changes except for `json` formatter. This refactoring is just opening up some classes to make it easier to integrate with this project.

- Shift `UrlGenerator` logic calls from `Formatter`s to `DiffEntry` - this dramatically reduces complexity of each formatter and makes them more consistent. It also allows using `DiffEntry` objects in other applications.
- Allows generating the diff from pre-existing `array` and not just files - this actually could make it easier to test but also allows the web version to use a simpler API
- `DiffEntry` is now much more powerful - it allows to fetch all details like versions, licenses and URLs in a really simple way.
- BC break: `DiffEntry` now requires passing `$urlGenerator` before `$direct` (should be fine if you haven't provided the second argument.
- BC break: Using custom URL generators requires calling `PackageDiff::setUrlGenerator()` but the call is optional - it uses default `GeneratorContainer` out of the box.
- BC break: `licenses` key in `json` formatter is now an `array` instead of `string|null` @giggsey you might need to adjust your flows if you rely on this key

**Note: All classes in this project are to be treated as `internal` as no BC promise is provided so far and they might change without prior notice. Backward compatibility is mostly provided for user-facing components like CLI arguments and formatters output.**

As always, all PHP versions from 5.3 all the way to 8.5+ are supported and 100% code coverage is maintained.