### PR TITLE
Flip Bitbucket versions for compare

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -24,6 +24,12 @@
             "ignore": [
                 "IonBazan\\ComposerDiff\\Formatter\\AbstractFormatter::terminalLink"
             ]
+        },
+        "ReturnRemoval": {
+            "ignore": [
+                "IonBazan\\ComposerDiff\\Formatter\\Helper\\Table::getColumnWidth",
+                "IonBazan\\ComposerDiff\\Command\\DiffCommand::hasDowngrades"
+            ]
         }
     }
 }

--- a/src/Url/BitBucketGenerator.php
+++ b/src/Url/BitBucketGenerator.php
@@ -31,20 +31,20 @@ class BitBucketGenerator extends GitGenerator
             return sprintf(
                 '%s/branches/compare/%s%%0D%s',
                 $baseUrl,
-                $this->getCompareRef($initialPackage),
-                $this->getCompareRef($targetPackage)
+                $this->getCompareRef($targetPackage),
+                $this->getCompareRef($initialPackage)
             );
         }
 
         return sprintf(
             '%s/branches/compare/%s/%s:%s%%0D%s/%s:%s',
             $baseUrl,
-            $baseUser,
-            $this->getRepo($initialPackage),
-            $this->getCompareRef($initialPackage),
             $targetUser,
             $this->getRepo($targetPackage),
-            $this->getCompareRef($targetPackage)
+            $this->getCompareRef($targetPackage),
+            $baseUser,
+            $this->getRepo($initialPackage),
+            $this->getCompareRef($initialPackage)
         );
     }
 

--- a/tests/Diff/DiffEntryTest.php
+++ b/tests/Diff/DiffEntryTest.php
@@ -97,6 +97,13 @@ class DiffEntryTest extends TestCase
         $this->assertNull($entry->getProjectUrl());
     }
 
+    public function testTypeForInvalidOperation()
+    {
+        $operation = $this->getMockBuilder('Composer\DependencyResolver\Operation\OperationInterface')->getMock();
+        $entry = new DiffEntry($operation);
+        $this->assertSame(DiffEntry::TYPE_CHANGE, $entry->getType());
+    }
+
     public function operationUrlProvider()
     {
         return array(

--- a/tests/Url/BitBucketGeneratorTest.php
+++ b/tests/Url/BitBucketGeneratorTest.php
@@ -64,32 +64,32 @@ class BitBucketGeneratorTest extends GeneratorTest
             'same maintainer' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://bitbucket.org/acme/package.git'),
                 $this->getPackageWithSource('acme/package', '3.12.1', 'https://bitbucket.org/acme/package.git'),
-                'https://bitbucket.org/acme/package/branches/compare/3.12.0%0D3.12.1',
+                'https://bitbucket.org/acme/package/branches/compare/3.12.1%0D3.12.0',
             ),
             'without .git' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://bitbucket.org/acme/package'),
                 $this->getPackageWithSource('acme/package', '3.12.1', 'https://bitbucket.org/acme/package'),
-                'https://bitbucket.org/acme/package/branches/compare/3.12.0%0D3.12.1',
+                'https://bitbucket.org/acme/package/branches/compare/3.12.1%0D3.12.0',
             ),
             'dev versions' => array(
                 $this->getPackageWithSource('acme/package', 'dev-master', 'https://bitbucket.org/acme/package.git', 'd46283075d76ed244f7825b378eeb1cee246af73'),
                 $this->getPackageWithSource('acme/package', 'dev-master', 'https://bitbucket.org/acme/package.git', '9b860214d58c48b5cbe99bdb17914d0eb723c9cd'),
-                'https://bitbucket.org/acme/package/branches/compare/d462830%0D9b86021',
+                'https://bitbucket.org/acme/package/branches/compare/9b86021%0Dd462830',
             ),
             'invalid or short reference' => array(
                 $this->getPackageWithSource('acme/package', 'dev-master', 'https://bitbucket.org/acme/package.git', 'd462830'),
                 $this->getPackageWithSource('acme/package', 'dev-master', 'https://bitbucket.org/acme/package.git', '1'),
-                'https://bitbucket.org/acme/package/branches/compare/d462830%0D1',
+                'https://bitbucket.org/acme/package/branches/compare/1%0Dd462830',
             ),
             'compare with base fork' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://bitbucket.org/IonBazan/package.git'),
                 $this->getPackageWithSource('acme/package', '3.12.1', 'https://bitbucket.org/acme/package.git'),
-                'https://bitbucket.org/acme/package/branches/compare/IonBazan/package:3.12.0%0Dacme/package:3.12.1',
+                'https://bitbucket.org/acme/package/branches/compare/acme/package:3.12.1%0DIonBazan/package:3.12.0',
             ),
             'compare with head fork' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://bitbucket.org/acme/package.git'),
                 $this->getPackageWithSource('acme/package', '3.12.1', 'https://bitbucket.org/IonBazan/package.git'),
-                'https://bitbucket.org/IonBazan/package/branches/compare/acme/package:3.12.0%0DIonBazan/package:3.12.1',
+                'https://bitbucket.org/IonBazan/package/branches/compare/IonBazan/package:3.12.1%0Dacme/package:3.12.0',
             ),
             'compare with different repository provider' => array(
                 $this->getPackageWithSource('acme/package', '3.12.0', 'https://bitbucket.org/acme/package.git'),


### PR DESCRIPTION
What i'm experiencing for Bitbucket is that the versions are flipped to what they should be

<img width="253" height="31" alt="image" src="https://github.com/user-attachments/assets/05e09041-980d-456c-8bd5-78f8ed18f474" />
<br>
<img width="446" height="147" alt="image" src="https://github.com/user-attachments/assets/ec2b0fad-1c0f-441a-bfb9-4f4726eb84bc" />


This change would result in them being

<img width="254" height="29" alt="image" src="https://github.com/user-attachments/assets/0cc6b11c-9426-471b-ad19-b0f97d40e520" />
<br>
<img width="430" height="115" alt="image" src="https://github.com/user-attachments/assets/343ae7a3-4623-4f31-a25c-7e4ba6ab826a" />
