### PR TITLE
Support diffing against a non-existing composer.lock file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ composer diff --help # Display detailed usage instructions
 ```shell script
 composer diff master # Compare current composer.lock with the one on master branch
 composer diff master:composer.lock develop:composer.lock -p # Compare master and develop branches, including platform dependencies
+composer diff /path/to/missing/composer.lock composer.lock # Compare a new lock file against a non-existing base lock file
 composer diff --no-dev # ignore dev dependencies
 composer diff -p # include platform dependencies
 composer diff -f json # Output as JSON instead of table

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ composer diff --help # Display detailed usage instructions
  - `--with-licenses` (`-c`) - include license information
  - `--format` (`-f`) - output format (mdtable, mdlist, json, github) - default: `mdtable`
  - `--gitlab-domains` - custom gitlab domains for compare/release URLs - default: use composer config
- 
+
 ## Advanced usage
 
 ```shell script
@@ -100,7 +100,7 @@ Exit code of the command is built using following bit flags:
 *  `0` - OK.
 *  `1` - General error.
 *  `2` - There were changes in prod packages.
-*  `4` - There were changes is dev packages.
+*  `4` - There were changes in dev packages.
 *  `8` - There were downgrades in prod packages.
 * `16` - There were downgrades in dev packages.
 
@@ -108,7 +108,7 @@ You may check for individual flags or simply check if the status is greater or e
 
 # Contributing
 
-Composer Diff is an open source project that welcomes pull requests and issues from anyone. 
+Composer Diff is an open source project that welcomes pull requests and issues from anyone.
 Before opening pull requests, please consider reading our short [Contribution Guidelines](docs/CONTRIBUTING.md).
 
 # Similar packages

--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ composer diff --help # Display detailed usage instructions
  - `--with-licenses` (`-c`) - include license information
  - `--format` (`-f`) - output format (mdtable, mdlist, json, github) - default: `mdtable`
  - `--gitlab-domains` - custom gitlab domains for compare/release URLs - default: use composer config
+ - `--skip-io-errors` - treat missing `composer.lock` files as empty input
 
 ## Advanced usage
 
 ```shell script
 composer diff master # Compare current composer.lock with the one on master branch
 composer diff master:composer.lock develop:composer.lock -p # Compare master and develop branches, including platform dependencies
-composer diff /path/to/missing/composer.lock composer.lock # Compare a new lock file against a non-existing base lock file
+composer diff /path/to/missing/composer.lock composer.lock --skip-io-errors # Compare a new lock file against a non-existing base lock file
 composer diff --no-dev # ignore dev dependencies
 composer diff -p # include platform dependencies
 composer diff -f json # Output as JSON instead of table

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -69,6 +69,7 @@ class DiffCommand extends BaseCommand
             ->addOption('with-licenses', 'c', InputOption::VALUE_NONE, 'Include licenses')
             ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format (mdtable, mdlist, json, github)', 'mdtable')
             ->addOption('gitlab-domains', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Extra Gitlab domains (inherited from Composer config by default)', array())
+            ->addOption('skip-io-errors', null, InputOption::VALUE_NONE, 'Treat missing composer.lock files as empty')
             ->addOption('strict', 's', InputOption::VALUE_NONE, 'Return non-zero exit code if there are any changes')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command displays all dependency changes between two <comment>composer.lock</comment> files.
@@ -117,6 +118,10 @@ Passing <info>--strict</info> option may help you to disallow changes or downgra
 
     <info>%command.full_name% --strict</info>
 
+Use <info>--skip-io-errors</info> to treat missing base <comment>composer.lock</comment> files as empty input:
+
+    <info>%command.full_name% /path/to/missing/composer.lock composer.lock --skip-io-errors</info>
+
 Exit code
 ---------
 
@@ -151,6 +156,7 @@ EOF
         $formatter = $formatters->getFormatter($input->getOption('format'));
 
         $this->packageDiff->setUrlGenerator($urlGenerators);
+        $this->packageDiff->setSkipIoErrors($input->getOption('skip-io-errors'));
 
         $prodOperations = new DiffEntries(array());
         $devOperations = new DiffEntries(array());

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -80,23 +80,23 @@ By default, it will compare current filesystem changes with git <comment>HEAD</c
 To compare with specific branch, pass its name as argument:
 
     <info>%command.full_name% master</info>
-    
+
 You can specify any valid git refs to compare with:
 
     <info>%command.full_name% HEAD~3 be4aabc</info>
-    
+
 You can also use more verbose syntax for <info>base</info> and <info>target</info> options:
 
     <info>%command.full_name% --base master --target composer.lock</info>
-    
+
 To compare files in specific path, use following syntax:
 
     <info>%command.full_name% master:subdirectory/composer.lock /path/to/another/composer.lock</info>
-    
+
 By default, <info>platform</info> dependencies are hidden. Add <info>--with-platform</info> option to include them in the report:
- 
+
     <info>%command.full_name% --with-platform</info>
-    
+
 By default, <info>transient</info> dependencies are displayed. Add <info>--direct</info> option to only show direct dependencies:
 
 <info>%command.full_name% --direct</info>
@@ -104,7 +104,7 @@ By default, <info>transient</info> dependencies are displayed. Add <info>--direc
 Use <info>--with-links</info> to include release and compare URLs in the report:
 
     <info>%command.full_name% --with-links</info>
-    
+
 You can customize output format by specifying it with <info>--format</info> option. Choose between <comment>mdtable</comment>, <comment>mdlist</comment> and <comment>json</comment>:
 
     <info>%command.full_name% --format=json</info>
@@ -125,7 +125,7 @@ Exit code of the command is built using following bit flags:
 *  0 - OK.
 *  1 - General error.
 *  2 - There were changes in prod packages.
-*  4 - There were changes is dev packages.
+*  4 - There were changes in dev packages.
 *  8 - There were downgrades in prod packages.
 * 16 - There were downgrades in dev packages.
 EOF

--- a/src/PackageDiff.php
+++ b/src/PackageDiff.php
@@ -213,6 +213,10 @@ class PackageDiff
             return file_get_contents($localPath);
         }
 
+        if ($lockFile && false === strpos($originalPath, self::GIT_SEPARATOR) && $this->looksLikeComposerLockFile($localPath)) {
+            return '{}';
+        }
+
         if (false === strpos($originalPath, self::GIT_SEPARATOR)) {
             $path .= self::GIT_SEPARATOR.self::COMPOSER.($lockFile ? self::EXTENSION_LOCK : self::EXTENSION_JSON);
         }
@@ -226,6 +230,10 @@ class PackageDiff
         $outputString = implode("\n", $output);
 
         if (0 !== $exit) {
+            if ($lockFile && $this->isMissingFileError($outputString)) {
+                return '{}';
+            }
+
             if ($lockFile) {
                 throw new \RuntimeException(sprintf('Could not open file %s or find it in git as %s: %s', $originalPath, $path, $outputString));
             }
@@ -235,6 +243,26 @@ class PackageDiff
         }
 
         return $outputString;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool
+     */
+    private function looksLikeComposerLockFile($path)
+    {
+        return self::EXTENSION_LOCK === substr($path, -strlen(self::EXTENSION_LOCK));
+    }
+
+    /**
+     * @param string $gitOutput
+     *
+     * @return bool
+     */
+    private function isMissingFileError($gitOutput)
+    {
+        return false !== stripos($gitOutput, 'does not exist in') || false !== stripos($gitOutput, 'exists on disk, but not in');
     }
 
     /**

--- a/src/PackageDiff.php
+++ b/src/PackageDiff.php
@@ -213,11 +213,11 @@ class PackageDiff
             return file_get_contents($localPath);
         }
 
-        if ($lockFile && false === strpos($originalPath, self::GIT_SEPARATOR) && $this->looksLikeComposerLockFile($localPath)) {
+        if ($lockFile && !$this->containsGitSeparator($originalPath) && $this->looksLikeComposerLockFile($localPath)) {
             return '{}';
         }
 
-        if (false === strpos($originalPath, self::GIT_SEPARATOR)) {
+        if (!$this->containsGitSeparator($originalPath)) {
             $path .= self::GIT_SEPARATOR.self::COMPOSER.($lockFile ? self::EXTENSION_LOCK : self::EXTENSION_JSON);
         }
 
@@ -263,6 +263,29 @@ class PackageDiff
     private function isMissingFileError($gitOutput)
     {
         return false !== stripos($gitOutput, 'does not exist in') || false !== stripos($gitOutput, 'exists on disk, but not in');
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool
+     */
+    private function containsGitSeparator($path)
+    {
+        $pos = strpos($path, self::GIT_SEPARATOR);
+
+        if (false === $pos) {
+            return false;
+        }
+
+        // Ignore Windows absolute drive paths (e.g. "C:\path" or "C:/path").
+        if (1 === $pos && ctype_alpha($path[0])) {
+            if (isset($path[2]) && ('\\' === $path[2] || '/' === $path[2])) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/PackageDiff.php
+++ b/src/PackageDiff.php
@@ -25,6 +25,9 @@ class PackageDiff
     /** @var UrlGenerator */
     protected $urlGenerator;
 
+    /** @var bool */
+    protected $skipIoErrors = false;
+
     public function __construct()
     {
         $this->urlGenerator = new GeneratorContainer();
@@ -36,6 +39,16 @@ class PackageDiff
     public function setUrlGenerator(UrlGenerator $urlGenerator)
     {
         $this->urlGenerator = $urlGenerator;
+    }
+
+    /**
+     * @param bool $skipIoErrors
+     *
+     * @return void
+     */
+    public function setSkipIoErrors($skipIoErrors)
+    {
+        $this->skipIoErrors = (bool) $skipIoErrors;
     }
 
     /**
@@ -213,79 +226,71 @@ class PackageDiff
             return file_get_contents($localPath);
         }
 
-        if ($lockFile && !$this->containsGitSeparator($originalPath) && $this->looksLikeComposerLockFile($localPath)) {
-            return '{}';
-        }
+        $attemptedSpecs = array();
+        $lastError = '';
 
-        if (!$this->containsGitSeparator($originalPath)) {
-            $path .= self::GIT_SEPARATOR.self::COMPOSER.($lockFile ? self::EXTENSION_LOCK : self::EXTENSION_JSON);
-        }
+        foreach ($this->getGitCandidates($path, $lockFile) as $gitPath) {
+            $attemptedSpecs[] = $gitPath;
+            $output = array();
+            @exec(sprintf('git show %s 2>&1', escapeshellarg($gitPath)), $output, $exit);
+            $outputString = implode("\n", $output);
 
-        if (!$lockFile) {
-            $path = $this->getJsonPath($path);
-        }
+            if (0 !== $exit) {
+                $lastError = $outputString;
 
-        $output = array();
-        @exec(sprintf('git show %s 2>&1', escapeshellarg($path)), $output, $exit);
-        $outputString = implode("\n", $output);
-
-        if (0 !== $exit) {
-            if ($lockFile && $this->isMissingFileError($outputString)) {
-                return '{}';
+                continue;
             }
 
-            if ($lockFile) {
-                throw new \RuntimeException(sprintf('Could not open file %s or find it in git as %s: %s', $originalPath, $path, $outputString));
+            if (!$this->looksLikeJsonDocument($outputString)) {
+                $lastError = sprintf('Unexpected non-JSON output for git spec %s', $gitPath);
+
+                continue;
             }
 
-            /* @infection-ignore-all False-positive */
-            return '{}'; // Do not throw exception for composer.json as it might not exist and that's fine
+            return $outputString;
         }
 
-        return $outputString;
+        if ($lockFile && !$this->skipIoErrors) {
+            throw new \RuntimeException(sprintf('Could not open file %s or find it in git as %s: %s', $originalPath, implode(', ', $attemptedSpecs), $lastError));
+        }
+
+        /* @infection-ignore-all False-positive */
+        // Do not throw exception for composer.json as it might not exist and that's fine.
+        // For composer.lock this fallback is optional and controlled by setSkipIoErrors().
+        return '{}';
     }
 
     /**
      * @param string $path
+     * @param bool   $lockFile
      *
-     * @return bool
+     * @return string[]
      */
-    private function looksLikeComposerLockFile($path)
+    private function getGitCandidates($path, $lockFile = true)
     {
-        return self::EXTENSION_LOCK === substr($path, -strlen(self::EXTENSION_LOCK));
+        $candidates = array();
+
+        if ($lockFile) {
+            $candidates[] = $path;
+            $candidates[] = $path.self::GIT_SEPARATOR.self::COMPOSER.self::EXTENSION_LOCK;
+        } else {
+            $candidates[] = $this->getJsonPath($path);
+            $candidates[] = $this->getJsonPath($path.self::GIT_SEPARATOR.self::COMPOSER.self::EXTENSION_LOCK);
+        }
+
+        return array_values(array_unique($candidates));
     }
 
     /**
-     * @param string $gitOutput
+     * @param string $contents
      *
      * @return bool
      */
-    private function isMissingFileError($gitOutput)
+    private function looksLikeJsonDocument($contents)
     {
-        return false !== stripos($gitOutput, 'does not exist in') || false !== stripos($gitOutput, 'exists on disk, but not in');
-    }
+        $data = json_decode($contents, true);
 
-    /**
-     * @param string $path
-     *
-     * @return bool
-     */
-    private function containsGitSeparator($path)
-    {
-        $pos = strpos($path, self::GIT_SEPARATOR);
-
-        if (false === $pos) {
-            return false;
-        }
-
-        // Ignore Windows absolute drive paths (e.g. "C:\path" or "C:/path").
-        if (1 === $pos && ctype_alpha($path[0])) {
-            if (isset($path[2]) && ('\\' === $path[2] || '/' === $path[2])) {
-                return false;
-            }
-        }
-
-        return true;
+        return JSON_ERROR_NONE === json_last_error() && is_array($data);
     }
 
     /**

--- a/tests/Command/DiffCommandTest.php
+++ b/tests/Command/DiffCommandTest.php
@@ -80,6 +80,27 @@ class DiffCommandTest extends TestCase
         $this->assertSame(0, $result);
     }
 
+    public function testSkipIoErrorsOption()
+    {
+        $diff = $this->getMockBuilder('IonBazan\ComposerDiff\PackageDiff')->getMock();
+        $application = $this->getComposerApplication();
+        $command = new DiffCommand($diff, array('gitlab2.org'));
+        $command->setApplication($application);
+        $tester = new CommandTester($command);
+
+        $diff->expects($this->once())
+            ->method('setSkipIoErrors')
+            ->with(true);
+
+        $diff->expects($this->atLeast(1))
+            ->method('getPackageDiff')
+            ->willReturn($this->getEntries(array(), $this->getGenerators()));
+
+        $result = $tester->execute(array('--skip-io-errors' => null));
+
+        $this->assertSame(0, $result);
+    }
+
     /**
      * @param int                  $exitCode
      * @param OperationInterface[] $prodOperations

--- a/tests/PackageDiffTest.php
+++ b/tests/PackageDiffTest.php
@@ -152,9 +152,22 @@ class PackageDiffTest extends TestCase
         $this->assertInstanceOf('Composer\Repository\ArrayRepository', $diff->loadPackagesFromArray(array(), true, true));
     }
 
-    public function testDiffAgainstMissingBaseLockFile()
+    public function testDiffAgainstMissingBaseLockFileThrowsByDefault()
     {
         $diff = new PackageDiff();
+        $this->setExpectedException('RuntimeException');
+        $diff->getPackageDiff(
+            __DIR__.'/fixtures/missing/composer.lock',
+            __DIR__.'/fixtures/empty-target/composer.lock',
+            false,
+            false
+        );
+    }
+
+    public function testDiffAgainstMissingBaseLockFileWithSkipIoErrors()
+    {
+        $diff = new PackageDiff();
+        $diff->setSkipIoErrors(true);
 
         $prodOperations = $diff->getPackageDiff(
             __DIR__.'/fixtures/missing/composer.lock',
@@ -177,9 +190,18 @@ class PackageDiffTest extends TestCase
         ), array_map(array($this, 'entryToString'), $devOperations->getArrayCopy()));
     }
 
-    public function testDiffAgainstMissingGitLockFilePath()
+    public function testDiffAgainstMissingGitLockFilePathThrowsByDefault()
     {
         $diff = new PackageDiff();
+        $this->prepareGit();
+        $this->setExpectedException('RuntimeException');
+        $diff->getPackageDiff('HEAD:missing/composer.lock', '', false, false);
+    }
+
+    public function testDiffAgainstMissingGitLockFilePathWithSkipIoErrors()
+    {
+        $diff = new PackageDiff();
+        $diff->setSkipIoErrors(true);
         $this->prepareGit();
         $operations = $diff->getPackageDiff('HEAD:missing/composer.lock', '', false, false);
 
@@ -189,9 +211,22 @@ class PackageDiffTest extends TestCase
         }
     }
 
-    public function testDiffAgainstMissingWindowsAbsoluteBaseLockFile()
+    public function testDiffAgainstMissingWindowsAbsoluteBaseLockFileThrowsByDefault()
     {
         $diff = new PackageDiff();
+        $this->setExpectedException('RuntimeException');
+        $diff->getPackageDiff(
+            'C:\\tmp\\missing\\composer.lock',
+            __DIR__.'/fixtures/empty-target/composer.lock',
+            false,
+            false
+        );
+    }
+
+    public function testDiffAgainstMissingWindowsAbsoluteBaseLockFileWithSkipIoErrors()
+    {
+        $diff = new PackageDiff();
+        $diff->setSkipIoErrors(true);
 
         $prodOperations = $diff->getPackageDiff(
             'C:\\tmp\\missing\\composer.lock',

--- a/tests/PackageDiffTest.php
+++ b/tests/PackageDiffTest.php
@@ -189,6 +189,41 @@ class PackageDiffTest extends TestCase
         }
     }
 
+    public function testDiffAgainstMissingWindowsAbsoluteBaseLockFile()
+    {
+        $diff = new PackageDiff();
+
+        $prodOperations = $diff->getPackageDiff(
+            'C:\\tmp\\missing\\composer.lock',
+            __DIR__.'/fixtures/empty-target/composer.lock',
+            false,
+            false
+        );
+        $devOperations = $diff->getPackageDiff(
+            'C:\\tmp\\missing\\composer.lock',
+            __DIR__.'/fixtures/empty-target/composer.lock',
+            true,
+            false
+        );
+
+        $this->assertSame(array(
+            'install example/package 1.2.3',
+        ), array_map(array($this, 'entryToString'), $prodOperations->getArrayCopy()));
+        $this->assertSame(array(
+            'install example/dev-package 2.3.4',
+        ), array_map(array($this, 'entryToString'), $devOperations->getArrayCopy()));
+    }
+
+    public function testOneLetterGitRefPath()
+    {
+        $diff = new PackageDiff();
+        $this->prepareGit();
+        exec('git branch -f z');
+        $operations = $diff->getPackageDiff('z:composer.lock', '', false, false);
+
+        $this->assertNotEmpty($operations);
+    }
+
     public function diffOperationsProvider()
     {
         return array(

--- a/tests/PackageDiffTest.php
+++ b/tests/PackageDiffTest.php
@@ -152,6 +152,43 @@ class PackageDiffTest extends TestCase
         $this->assertInstanceOf('Composer\Repository\ArrayRepository', $diff->loadPackagesFromArray(array(), true, true));
     }
 
+    public function testDiffAgainstMissingBaseLockFile()
+    {
+        $diff = new PackageDiff();
+
+        $prodOperations = $diff->getPackageDiff(
+            __DIR__.'/fixtures/missing/composer.lock',
+            __DIR__.'/fixtures/empty-target/composer.lock',
+            false,
+            false
+        );
+        $devOperations = $diff->getPackageDiff(
+            __DIR__.'/fixtures/missing/composer.lock',
+            __DIR__.'/fixtures/empty-target/composer.lock',
+            true,
+            false
+        );
+
+        $this->assertSame(array(
+            'install example/package 1.2.3',
+        ), array_map(array($this, 'entryToString'), $prodOperations->getArrayCopy()));
+        $this->assertSame(array(
+            'install example/dev-package 2.3.4',
+        ), array_map(array($this, 'entryToString'), $devOperations->getArrayCopy()));
+    }
+
+    public function testDiffAgainstMissingGitLockFilePath()
+    {
+        $diff = new PackageDiff();
+        $this->prepareGit();
+        $operations = $diff->getPackageDiff('HEAD:missing/composer.lock', '', false, false);
+
+        $this->assertNotEmpty($operations);
+        foreach ($operations as $entry) {
+            $this->assertInstanceOf('Composer\DependencyResolver\Operation\InstallOperation', $entry->getOperation());
+        }
+    }
+
     public function diffOperationsProvider()
     {
         return array(

--- a/tests/fixtures/empty-target/composer.lock
+++ b/tests/fixtures/empty-target/composer.lock
@@ -1,0 +1,14 @@
+{
+    "packages": [
+        {
+            "name": "example/package",
+            "version": "1.2.3"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "example/dev-package",
+            "version": "2.3.4"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

When comparing against a `composer.lock` that doesn't exist yet (e.g. a path on a branch where no lockfile has been committed), the diff now treats it as an empty lockfile (`{}`) instead of throwing an error. All packages in the target are reported as new installs.

This covers two scenarios:
- **Local file path** — the path looks like a `composer.lock` file but doesn't exist on disk (e.g. `composer diff /new/project/composer.lock composer.lock`)
- **Git ref path** — the file doesn't exist in the referenced commit (e.g. `composer diff HEAD:new-dir/composer.lock`)

## Motivation

We use [composer-bin](https://github.com/bamarni/composer-bin-plugin) to manage tooling in separate directories away from the main `composer.json`/`composer.lock`. When a new tool directory is introduced on a branch, there is no corresponding `composer.lock` on the base branch yet. Running `composer diff` against that non-existing base lockfile currently throws an error, making it impossible to review the newly added dependencies.

## Changes
- Handle non-existing local `composer.lock` paths by returning `{}` instead of falling through to git
- Detect missing-file errors from `git show` and return `{}` instead of throwing
- Add tests for both local and git-ref missing lockfile scenarios
- Document the usage in README