### PR TITLE
Add --filter option to restrict output to matching packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ composer diff --help # Display detailed usage instructions
  - `--with-licenses` (`-c`) - include license information
  - `--format` (`-f`) - output format (mdtable, mdlist, json, github) - default: `mdtable`
  - `--gitlab-domains` - custom gitlab domains for compare/release URLs - default: use composer config
+ - `--filter` - limit output to packages matching the given glob pattern (e.g. `symfony/*`); can be specified multiple times
  
 ## Advanced usage
 
@@ -89,6 +90,8 @@ composer diff master:composer.lock develop:composer.lock -p # Compare master and
 composer diff --no-dev # ignore dev dependencies
 composer diff -p # include platform dependencies
 composer diff -f json # Output as JSON instead of table
+composer diff --filter="symfony/*" # Show only symfony packages
+composer diff --filter="symfony/*" --filter="doctrine/*" # Show symfony and doctrine packages
 ```
 
 You can find more documentation in the [docs](docs) directory.

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -56,6 +56,7 @@ class DiffCommand extends BaseCommand
             ->addOption('with-licenses', 'c', InputOption::VALUE_NONE, 'Include licenses')
             ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format (mdtable, mdlist, json, github)', 'mdtable')
             ->addOption('gitlab-domains', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Extra Gitlab domains (inherited from Composer config by default)', [])
+            ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Limit output to packages matching given glob pattern(s)', [])
             ->addOption('strict', 's', InputOption::VALUE_NONE, 'Return non-zero exit code if there are any changes')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command displays all dependency changes between two <comment>composer.lock</comment> files.
@@ -138,6 +139,7 @@ EOF
 
         $prodOperations = new DiffEntries([]);
         $devOperations = new DiffEntries([]);
+        $filters = $input->getOption('filter');
 
         if (!$input->getOption('no-prod')) {
             $prodOperations = $this->packageDiff->getPackageDiff($base, $target, false, $withPlatform, $onlyDirect);
@@ -145,6 +147,11 @@ EOF
 
         if (!$input->getOption('no-dev')) {
             $devOperations = $this->packageDiff->getPackageDiff($base, $target, true, $withPlatform, $onlyDirect);
+        }
+
+        if (!empty($filters)) {
+            $prodOperations = $prodOperations->matching($filters);
+            $devOperations = $devOperations->matching($filters);
         }
 
         $formatter->render($prodOperations, $devOperations, $withUrls, $withLicenses);

--- a/src/Diff/DiffEntries.php
+++ b/src/Diff/DiffEntries.php
@@ -3,10 +3,31 @@
 namespace IonBazan\ComposerDiff\Diff;
 
 use ArrayIterator;
+use Composer\Package\BasePackage;
+use Composer\Pcre\Preg;
 
 /**
  * @extends ArrayIterator<int, DiffEntry>
  */
 class DiffEntries extends ArrayIterator
 {
+    /**
+     * Returns a new collection containing only entries whose package name matches at least one of the given glob patterns.
+     *
+     * @param string[] $patterns
+     */
+    public function matching(array $patterns): self
+    {
+        $regexp = BasePackage::packageNamesToRegexp($patterns);
+        $filtered = [];
+
+        /** @var DiffEntry $entry */
+        foreach ($this as $entry) {
+            if (Preg::isMatch($regexp, $entry->getPackageName())) {
+                $filtered[] = $entry;
+            }
+        }
+
+        return new self($filtered);
+    }
 }

--- a/tests/Command/DiffCommandTest.php
+++ b/tests/Command/DiffCommandTest.php
@@ -46,6 +46,50 @@ class DiffCommandTest extends TestCase
         $this->assertSame($expectedOutput, $tester->getDisplay());
     }
 
+    public function testFilterOption(): void
+    {
+        $diff = $this->getMockBuilder(PackageDiff::class)->getMock();
+        $application = $this->getComposerApplication();
+        $command = new DiffCommand($diff);
+        $command->setApplication($application);
+        $tester = new CommandTester($command);
+        $diff->expects($this->atLeast(1))
+            ->method('getPackageDiff')
+            ->willReturn($this->getEntries([
+                new InstallOperation($this->getPackageWithSource('symfony/console', '6.0.0', 'github.com')),
+                new InstallOperation($this->getPackageWithSource('doctrine/orm', '2.0.0', 'github.com')),
+                new InstallOperation($this->getPackageWithSource('symfony/http-kernel', '6.0.0', 'github.com')),
+            ], $this->getGenerators()))
+        ;
+        $tester->execute(['--filter' => ['symfony/*']]);
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('symfony/console', $output);
+        $this->assertStringContainsString('symfony/http-kernel', $output);
+        $this->assertStringNotContainsString('doctrine/orm', $output);
+    }
+
+    public function testMultipleFilterPatterns(): void
+    {
+        $diff = $this->getMockBuilder(PackageDiff::class)->getMock();
+        $application = $this->getComposerApplication();
+        $command = new DiffCommand($diff);
+        $command->setApplication($application);
+        $tester = new CommandTester($command);
+        $diff->expects($this->atLeast(1))
+            ->method('getPackageDiff')
+            ->willReturn($this->getEntries([
+                new InstallOperation($this->getPackageWithSource('symfony/console', '6.0.0', 'github.com')),
+                new InstallOperation($this->getPackageWithSource('doctrine/orm', '2.0.0', 'github.com')),
+                new InstallOperation($this->getPackageWithSource('twig/twig', '3.0.0', 'github.com')),
+            ], $this->getGenerators()))
+        ;
+        $tester->execute(['--filter' => ['symfony/*', 'doctrine/*']]);
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('symfony/console', $output);
+        $this->assertStringContainsString('doctrine/orm', $output);
+        $this->assertStringNotContainsString('twig/twig', $output);
+    }
+
     public function testExtraGitlabDomains(): void
     {
         $diff = $this->getMockBuilder(PackageDiff::class)->getMock();


### PR DESCRIPTION
## Summary

Adds a `--filter` option that limits diff output to packages whose name matches one or more glob patterns. Multiple patterns are OR-ed together.

```bash
# Single vendor
composer diff --filter="symfony/*"

# Multiple vendors
composer diff --filter="symfony/*" --filter="doctrine/*"
```

Pattern matching uses the same regex-based approach as Composer's own `FilterRepository` — via `BasePackage::packageNamesToRegexp()` — so behaviour is consistent with what Composer users already know, and it works correctly on Windows (no `fnmatch()` dependency).

The matching logic is implemented as `DiffEntries::matching(array $patterns): self` so it is available to any consumer of the collection, not just the command.