### PR TITLE
Add --sort option to order output alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ composer diff --help # Display detailed usage instructions
  - `--format` (`-f`) - output format (mdtable, mdlist, json, github) - default: `mdtable`
  - `--gitlab-domains` - custom gitlab domains for compare/release URLs - default: use composer config
  - `--filter` - limit output to packages matching the given glob pattern (e.g. `symfony/*`); can be specified multiple times
+ - `--sort` - sort packages alphabetically by name; use `--sort=operation` to group by operation type (installs, upgrades, downgrades, removals)
  
 ## Advanced usage
 
@@ -92,6 +93,8 @@ composer diff -p # include platform dependencies
 composer diff -f json # Output as JSON instead of table
 composer diff --filter="symfony/*" # Show only symfony packages
 composer diff --filter="symfony/*" --filter="doctrine/*" # Show symfony and doctrine packages
+composer diff --sort # Sort packages alphabetically by name
+composer diff --sort=operation # Group packages by operation type (installs, upgrades, downgrades, removals)
 ```
 
 You can find more documentation in the [docs](docs) directory.

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -57,6 +57,7 @@ class DiffCommand extends BaseCommand
             ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format (mdtable, mdlist, json, github)', 'mdtable')
             ->addOption('gitlab-domains', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Extra Gitlab domains (inherited from Composer config by default)', [])
             ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Limit output to packages matching given glob pattern(s)', [])
+            ->addOption('sort', null, InputOption::VALUE_OPTIONAL, 'Sort packages by "name" or "operation"', false)
             ->addOption('strict', 's', InputOption::VALUE_NONE, 'Return non-zero exit code if there are any changes')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command displays all dependency changes between two <comment>composer.lock</comment> files.
@@ -100,6 +101,16 @@ You can customize output format by specifying it with <info>--format</info> opti
 Hide <info>dev</info> dependencies using <info>--no-dev</info> option:
 
     <info>%command.full_name% --no-dev</info>
+
+Use <info>--filter</info> to restrict output to packages matching a glob pattern:
+
+    <info>%command.full_name% --filter="symfony/*"</info>
+    <info>%command.full_name% --filter="symfony/*" --filter="doctrine/*"</info>
+
+Use <info>--sort</info> to order packages alphabetically by name, or <info>--sort=operation</info> to group by operation type:
+
+    <info>%command.full_name% --sort</info>
+    <info>%command.full_name% --sort=operation</info>
 
 Passing <info>--strict</info> option may help you to disallow changes or downgrades by returning non-zero exit code:
 
@@ -152,6 +163,13 @@ EOF
         if (!empty($filters)) {
             $prodOperations = $prodOperations->matching($filters);
             $devOperations = $devOperations->matching($filters);
+        }
+
+        $sort = $input->getOption('sort');
+        if (false !== $sort) {
+            $sortBy = is_string($sort) ? $sort : 'name';
+            $prodOperations = $prodOperations->sorted($sortBy);
+            $devOperations = $devOperations->sorted($sortBy);
         }
 
         $formatter->render($prodOperations, $devOperations, $withUrls, $withLicenses);

--- a/src/Diff/DiffEntries.php
+++ b/src/Diff/DiffEntries.php
@@ -41,16 +41,16 @@ class DiffEntries extends ArrayIterator
         $entries = $this->getArrayCopy();
 
         if ('operation' === $by) {
-            $order = [
-                DiffEntry::TYPE_INSTALL => 0,
-                DiffEntry::TYPE_UPGRADE => 1,
-                DiffEntry::TYPE_DOWNGRADE => 2,
-                DiffEntry::TYPE_CHANGE => 3,
-                DiffEntry::TYPE_REMOVE => 4,
-            ];
+            $order = array_flip([
+                DiffEntry::TYPE_INSTALL,
+                DiffEntry::TYPE_UPGRADE,
+                DiffEntry::TYPE_DOWNGRADE,
+                DiffEntry::TYPE_CHANGE,
+                DiffEntry::TYPE_REMOVE,
+            ]);
 
             usort($entries, static function (DiffEntry $a, DiffEntry $b) use ($order): int {
-                $cmp = ($order[$a->getType()] ?? 99) - ($order[$b->getType()] ?? 99);
+                $cmp = $order[$a->getType()] - $order[$b->getType()];
                 if (0 !== $cmp) {
                     return $cmp;
                 }

--- a/src/Diff/DiffEntries.php
+++ b/src/Diff/DiffEntries.php
@@ -30,4 +30,39 @@ class DiffEntries extends ArrayIterator
 
         return new self($filtered);
     }
+
+    /**
+     * Returns a new collection sorted by package name or operation type.
+     *
+     * @param string $by 'name' or 'operation'
+     */
+    public function sorted(string $by = 'name'): self
+    {
+        $entries = $this->getArrayCopy();
+
+        if ('operation' === $by) {
+            $order = [
+                DiffEntry::TYPE_INSTALL => 0,
+                DiffEntry::TYPE_UPGRADE => 1,
+                DiffEntry::TYPE_DOWNGRADE => 2,
+                DiffEntry::TYPE_CHANGE => 3,
+                DiffEntry::TYPE_REMOVE => 4,
+            ];
+
+            usort($entries, static function (DiffEntry $a, DiffEntry $b) use ($order): int {
+                $cmp = ($order[$a->getType()] ?? 99) - ($order[$b->getType()] ?? 99);
+                if (0 !== $cmp) {
+                    return $cmp;
+                }
+
+                return strcmp($a->getPackageName(), $b->getPackageName());
+            });
+        } else {
+            usort($entries, static function (DiffEntry $a, DiffEntry $b): int {
+                return strcmp($a->getPackageName(), $b->getPackageName());
+            });
+        }
+
+        return new self($entries);
+    }
 }

--- a/tests/Command/DiffCommandTest.php
+++ b/tests/Command/DiffCommandTest.php
@@ -68,6 +68,56 @@ class DiffCommandTest extends TestCase
         $this->assertStringNotContainsString('doctrine/orm', $output);
     }
 
+    public function testSortByName(): void
+    {
+        $diff = $this->getMockBuilder(PackageDiff::class)->getMock();
+        $application = $this->getComposerApplication();
+        $command = new DiffCommand($diff);
+        $command->setApplication($application);
+        $tester = new CommandTester($command);
+        $diff->expects($this->atLeast(1))
+            ->method('getPackageDiff')
+            ->willReturn($this->getEntries([
+                new InstallOperation($this->getPackageWithSource('symfony/console', '6.0.0', 'github.com')),
+                new InstallOperation($this->getPackageWithSource('doctrine/orm', '2.0.0', 'github.com')),
+                new InstallOperation($this->getPackageWithSource('symfony/http-kernel', '6.0.0', 'github.com')),
+            ], $this->getGenerators()))
+        ;
+        $tester->execute(['--sort' => null]);
+        $output = $tester->getDisplay();
+        $pos1 = strpos($output, 'doctrine/orm');
+        $pos2 = strpos($output, 'symfony/console');
+        $pos3 = strpos($output, 'symfony/http-kernel');
+        $this->assertNotFalse($pos1);
+        $this->assertNotFalse($pos2);
+        $this->assertNotFalse($pos3);
+        $this->assertLessThan($pos2, $pos1);
+        $this->assertLessThan($pos3, $pos2);
+    }
+
+    public function testSortByOperation(): void
+    {
+        $diff = $this->getMockBuilder(PackageDiff::class)->getMock();
+        $application = $this->getComposerApplication();
+        $command = new DiffCommand($diff);
+        $command->setApplication($application);
+        $tester = new CommandTester($command);
+        $diff->expects($this->atLeast(1))
+            ->method('getPackageDiff')
+            ->willReturn($this->getEntries([
+                new UninstallOperation($this->getPackageWithSource('b/package', '1.0.0', 'github.com')),
+                new InstallOperation($this->getPackageWithSource('a/package', '2.0.0', 'github.com')),
+            ], $this->getGenerators()))
+        ;
+        $tester->execute(['--sort' => 'operation']);
+        $output = $tester->getDisplay();
+        $installPos = strpos($output, 'a/package');
+        $removePos = strpos($output, 'b/package');
+        $this->assertNotFalse($installPos);
+        $this->assertNotFalse($removePos);
+        $this->assertLessThan($removePos, $installPos);
+    }
+
     public function testMultipleFilterPatterns(): void
     {
         $diff = $this->getMockBuilder(PackageDiff::class)->getMock();

--- a/tests/Diff/DiffEntriesTest.php
+++ b/tests/Diff/DiffEntriesTest.php
@@ -47,6 +47,7 @@ class DiffEntriesTest extends TestCase
             new DiffEntry(new UpdateOperation($this->getPackage('a/downgrade', '2.0.0'), $this->getPackage('a/downgrade', '1.0.0'))),
             new DiffEntry(new InstallOperation($this->getPackage('a/install', '1.0.0'))),
             new DiffEntry(new UninstallOperation($this->getPackage('a/remove', '1.0.0'))),
+            new DiffEntry(new UpdateOperation($this->getPackage('a/change', 'dev-main'), $this->getPackage('a/change', 'dev-feature'))),
         ]);
 
         $sorted = $entries->sorted('operation');
@@ -57,6 +58,7 @@ class DiffEntriesTest extends TestCase
             'b/install',
             'a/upgrade',
             'a/downgrade',
+            'a/change',
             'a/remove',
             'b/remove',
         ], $names);

--- a/tests/Diff/DiffEntriesTest.php
+++ b/tests/Diff/DiffEntriesTest.php
@@ -20,7 +20,7 @@ class DiffEntriesTest extends TestCase
         ]);
 
         $sorted = $entries->sorted('name');
-        $names = array_map(static fn (DiffEntry $e) => $e->getPackageName(), $sorted->getArrayCopy());
+        $names = array_map(static function (DiffEntry $e) { return $e->getPackageName(); }, $sorted->getArrayCopy());
 
         $this->assertSame(['a/package', 'b/package', 'c/package'], $names);
     }
@@ -33,7 +33,7 @@ class DiffEntriesTest extends TestCase
         ]);
 
         $sorted = $entries->sorted();
-        $names = array_map(static fn (DiffEntry $e) => $e->getPackageName(), $sorted->getArrayCopy());
+        $names = array_map(static function (DiffEntry $e) { return $e->getPackageName(); }, $sorted->getArrayCopy());
 
         $this->assertSame(['a/package', 'b/package'], $names);
     }
@@ -50,7 +50,7 @@ class DiffEntriesTest extends TestCase
         ]);
 
         $sorted = $entries->sorted('operation');
-        $names = array_map(static fn (DiffEntry $e) => $e->getPackageName(), $sorted->getArrayCopy());
+        $names = array_map(static function (DiffEntry $e) { return $e->getPackageName(); }, $sorted->getArrayCopy());
 
         $this->assertSame([
             'a/install',
@@ -71,10 +71,10 @@ class DiffEntriesTest extends TestCase
 
         $sorted = $entries->sorted();
 
-        $originalNames = array_map(static fn (DiffEntry $e) => $e->getPackageName(), $entries->getArrayCopy());
+        $originalNames = array_map(static function (DiffEntry $e) { return $e->getPackageName(); }, $entries->getArrayCopy());
         $this->assertSame(['b/package', 'a/package'], $originalNames);
 
-        $sortedNames = array_map(static fn (DiffEntry $e) => $e->getPackageName(), $sorted->getArrayCopy());
+        $sortedNames = array_map(static function (DiffEntry $e) { return $e->getPackageName(); }, $sorted->getArrayCopy());
         $this->assertSame(['a/package', 'b/package'], $sortedNames);
     }
 }

--- a/tests/Diff/DiffEntriesTest.php
+++ b/tests/Diff/DiffEntriesTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Tests\Diff;
+
+use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\UninstallOperation;
+use Composer\DependencyResolver\Operation\UpdateOperation;
+use IonBazan\ComposerDiff\Diff\DiffEntries;
+use IonBazan\ComposerDiff\Diff\DiffEntry;
+use IonBazan\ComposerDiff\Tests\TestCase;
+
+class DiffEntriesTest extends TestCase
+{
+    public function testSortedByName(): void
+    {
+        $entries = new DiffEntries([
+            new DiffEntry(new InstallOperation($this->getPackage('b/package', '1.0.0'))),
+            new DiffEntry(new UninstallOperation($this->getPackage('a/package', '1.0.0'))),
+            new DiffEntry(new InstallOperation($this->getPackage('c/package', '1.0.0'))),
+        ]);
+
+        $sorted = $entries->sorted('name');
+        $names = array_map(static fn (DiffEntry $e) => $e->getPackageName(), $sorted->getArrayCopy());
+
+        $this->assertSame(['a/package', 'b/package', 'c/package'], $names);
+    }
+
+    public function testSortedByNameIsDefault(): void
+    {
+        $entries = new DiffEntries([
+            new DiffEntry(new InstallOperation($this->getPackage('b/package', '1.0.0'))),
+            new DiffEntry(new UninstallOperation($this->getPackage('a/package', '1.0.0'))),
+        ]);
+
+        $sorted = $entries->sorted();
+        $names = array_map(static fn (DiffEntry $e) => $e->getPackageName(), $sorted->getArrayCopy());
+
+        $this->assertSame(['a/package', 'b/package'], $names);
+    }
+
+    public function testSortedByOperation(): void
+    {
+        $entries = new DiffEntries([
+            new DiffEntry(new UninstallOperation($this->getPackage('b/remove', '1.0.0'))),
+            new DiffEntry(new InstallOperation($this->getPackage('b/install', '1.0.0'))),
+            new DiffEntry(new UpdateOperation($this->getPackage('a/upgrade', '1.0.0'), $this->getPackage('a/upgrade', '2.0.0'))),
+            new DiffEntry(new UpdateOperation($this->getPackage('a/downgrade', '2.0.0'), $this->getPackage('a/downgrade', '1.0.0'))),
+            new DiffEntry(new InstallOperation($this->getPackage('a/install', '1.0.0'))),
+            new DiffEntry(new UninstallOperation($this->getPackage('a/remove', '1.0.0'))),
+        ]);
+
+        $sorted = $entries->sorted('operation');
+        $names = array_map(static fn (DiffEntry $e) => $e->getPackageName(), $sorted->getArrayCopy());
+
+        $this->assertSame([
+            'a/install',
+            'b/install',
+            'a/upgrade',
+            'a/downgrade',
+            'a/remove',
+            'b/remove',
+        ], $names);
+    }
+
+    public function testSortedDoesNotMutateOriginal(): void
+    {
+        $entries = new DiffEntries([
+            new DiffEntry(new InstallOperation($this->getPackage('b/package', '1.0.0'))),
+            new DiffEntry(new InstallOperation($this->getPackage('a/package', '1.0.0'))),
+        ]);
+
+        $sorted = $entries->sorted();
+
+        $originalNames = array_map(static fn (DiffEntry $e) => $e->getPackageName(), $entries->getArrayCopy());
+        $this->assertSame(['b/package', 'a/package'], $originalNames);
+
+        $sortedNames = array_map(static fn (DiffEntry $e) => $e->getPackageName(), $sorted->getArrayCopy());
+        $this->assertSame(['a/package', 'b/package'], $sortedNames);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `--sort` (or `--sort=name`) option to sort packages alphabetically by name within each section
- Adds `--sort=operation` to group packages by operation type: installs → upgrades → downgrades → changes → removals; ties broken alphabetically
- Sorting is non-destructive — the original lock file order is preserved when `--sort` is not used
- Updates README and command help text with `--filter` examples (previously undocumented in help) and the new `--sort` option

Closes #48