### PR TITLE
Add collapsible PR formatter (--format=pr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ composer diff --help # Display detailed usage instructions
  - `--with-platform` (`-p`) - include platform dependencies (PHP, extensions, etc.)
  - `--with-links` (`-l`) - include compare/release URLs
  - `--with-licenses` (`-c`) - include license information
- - `--format` (`-f`) - output format (mdtable, mdlist, json, github) - default: `mdtable`
+ - `--format` (`-f`) - output format (mdtable, mdlist, json, github, pr) - default: `mdtable`
  - `--gitlab-domains` - custom gitlab domains for compare/release URLs - default: use composer config
  - `--filter` - limit output to packages matching the given glob pattern (e.g. `symfony/*`); can be specified multiple times
  - `--sort` - sort packages alphabetically by name; use `--sort=operation` to group by operation type (installs, upgrades, downgrades, removals)
@@ -91,6 +91,7 @@ composer diff master:composer.lock develop:composer.lock -p # Compare master and
 composer diff --no-dev # ignore dev dependencies
 composer diff -p # include platform dependencies
 composer diff -f json # Output as JSON instead of table
+composer diff -f pr # Collapsible <details> blocks for GitHub PR descriptions
 composer diff --filter="symfony/*" # Show only symfony packages
 composer diff --filter="symfony/*" --filter="doctrine/*" # Show symfony and doctrine packages
 composer diff --sort # Sort packages alphabetically by name

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -54,7 +54,7 @@ class DiffCommand extends BaseCommand
             ->addOption('with-platform', 'p', InputOption::VALUE_NONE, 'Include platform dependencies (PHP version, extensions, etc.)')
             ->addOption('with-links', 'l', InputOption::VALUE_NONE, 'Include compare/release URLs')
             ->addOption('with-licenses', 'c', InputOption::VALUE_NONE, 'Include licenses')
-            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format (mdtable, mdlist, json, github)', 'mdtable')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format (mdtable, mdlist, json, github, pr)', 'mdtable')
             ->addOption('gitlab-domains', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Extra Gitlab domains (inherited from Composer config by default)', [])
             ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Limit output to packages matching given glob pattern(s)', [])
             ->addOption('sort', null, InputOption::VALUE_OPTIONAL, 'Sort packages by "name" or "operation"', false)
@@ -94,9 +94,13 @@ Use <info>--with-links</info> to include release and compare URLs in the report:
 
     <info>%command.full_name% --with-links</info>
     
-You can customize output format by specifying it with <info>--format</info> option. Choose between <comment>mdtable</comment>, <comment>mdlist</comment> and <comment>json</comment>:
+You can customize output format by specifying it with <info>--format</info> option. Choose between <comment>mdtable</comment>, <comment>mdlist</comment>, <comment>json</comment>, <comment>github</comment> and <comment>pr</comment>:
 
     <info>%command.full_name% --format=json</info>
+
+Use <info>--format=pr</info> to wrap the output in collapsible <comment><details></comment> blocks, suitable for GitHub PR descriptions:
+
+    <info>%command.full_name% --format=pr</info>
 
 Hide <info>dev</info> dependencies using <info>--no-dev</info> option:
 

--- a/src/Formatter/FormatterContainer.php
+++ b/src/Formatter/FormatterContainer.php
@@ -20,6 +20,7 @@ class FormatterContainer
             'mdlist' => new MarkdownListFormatter($output),
             'github' => new GitHubFormatter($output),
             'json' => new JsonFormatter($output),
+            'pr' => new GithubPrFormatter($output),
         ];
     }
 

--- a/src/Formatter/GithubPrFormatter.php
+++ b/src/Formatter/GithubPrFormatter.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Formatter;
+
+use IonBazan\ComposerDiff\Diff\DiffEntries;
+use function count;
+
+class GithubPrFormatter extends MarkdownTableFormatter
+{
+    public function renderSingle(DiffEntries $entries, string $title, bool $withUrls, bool $withLicenses): void
+    {
+        if (!count($entries)) {
+            return;
+        }
+
+        $this->output->writeln('<details>');
+        $this->output->writeln(sprintf('<summary>%s (%d packages)</summary>', $title, count($entries)));
+        $this->output->writeln('');
+        parent::renderSingle($entries, $title, $withUrls, $withLicenses);
+        $this->output->writeln('</details>');
+        $this->output->writeln('');
+    }
+}

--- a/tests/Formatter/FormatterContainerTest.php
+++ b/tests/Formatter/FormatterContainerTest.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use IonBazan\ComposerDiff\Formatter\MarkdownListFormatter;
 use IonBazan\ComposerDiff\Formatter\JsonFormatter;
 use IonBazan\ComposerDiff\Formatter\GitHubFormatter;
+use IonBazan\ComposerDiff\Formatter\GithubPrFormatter;
 use IonBazan\ComposerDiff\Formatter\FormatterContainer;
 use IonBazan\ComposerDiff\Formatter\MarkdownTableFormatter;
 use IonBazan\ComposerDiff\Tests\TestCase;
@@ -36,6 +37,7 @@ class FormatterContainerTest extends TestCase
             [MarkdownListFormatter::class, 'mdlist'],
             [JsonFormatter::class, 'json'],
             [GitHubFormatter::class, 'github'],
+            [GithubPrFormatter::class, 'pr'],
             [MarkdownTableFormatter::class, 'anything-else'],
         ];
     }

--- a/tests/Formatter/GithubPrFormatterTest.php
+++ b/tests/Formatter/GithubPrFormatterTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace IonBazan\ComposerDiff\Tests\Formatter;
+
+use IonBazan\ComposerDiff\Formatter\Formatter;
+use IonBazan\ComposerDiff\Formatter\GithubPrFormatter;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GithubPrFormatterTest extends FormatterTest
+{
+    protected function getSampleOutput(bool $withUrls, bool $withLicenses, bool $decorated): string
+    {
+        if ($withLicenses) {
+            $prodLicenseHeader = ' License |';
+            $prodLicenseSeparator = '---------|';
+            $prodNullLicense = '         |';
+
+            $devLicenseHeader = ' License           |';
+            $devLicenseSeparator = '-------------------|';
+            $devNullLicense = '                   |';
+            $package4License = ' MIT, BSD-3-Clause |';
+            $noLink2License = ' MIT               |';
+        } else {
+            $prodLicenseHeader = '';
+            $prodLicenseSeparator = '';
+            $prodNullLicense = '';
+            $devLicenseHeader = '';
+            $devLicenseSeparator = '';
+            $devNullLicense = '';
+            $package4License = '';
+            $noLink2License = '';
+        }
+
+        if ($withUrls) {
+            if ($decorated) {
+                if ($this->supportsLinks()) {
+                    return <<<OUTPUT
+<details>
+<summary>Prod Packages (6 packages)</summary>
+
+| Prod Packages                                    | Operation  | Base    | Target | Link                                          |{$prodLicenseHeader}
+|--------------------------------------------------|------------|---------|--------|-----------------------------------------------|{$prodLicenseSeparator}
+| []8;;https://example.com/r/a/package-1\\a/package-1]8;;\\](https://example.com/r/a/package-1) | [32mNew[39m        | -       | 1.0.0  | [Compare](https://example.com/r/1.0.0)        |{$prodNullLicense}
+| a/no-link-1                                      | [32mNew[39m        | -       | 1.0.0  |                                               |{$prodNullLicense}
+| []8;;https://example.com/r/a/package-2\\a/package-2]8;;\\](https://example.com/r/a/package-2) | [36mUpgraded[39m   | 1.0.0   | 1.2.0  | [Compare](https://example.com/c/1.0.0..1.2.0) |{$prodNullLicense}
+| []8;;https://example.com/r/a/package-3\\a/package-3]8;;\\](https://example.com/r/a/package-3) | [33mDowngraded[39m | 2.0.0   | 1.1.1  | [Compare](https://example.com/c/2.0.0..1.1.1) |{$prodNullLicense}
+| a/no-link-2                                      | [33mDowngraded[39m | 2.0.0   | 1.1.1  |                                               |{$prodNullLicense}
+| php                                              | [35mChanged[39m    | >=7.4.6 | ^8.0   |                                               |{$prodNullLicense}
+
+</details>
+
+<details>
+<summary>Dev Packages (3 packages)</summary>
+
+| Dev Packages                                     | Operation | Base               | Target | Link                                               |{$devLicenseHeader}
+|--------------------------------------------------|-----------|--------------------|--------|----------------------------------------------------|{$devLicenseSeparator}
+| []8;;https://example.com/r/a/package-5\\a/package-5]8;;\\](https://example.com/r/a/package-5) | [35mChanged[39m   | dev-master 1234567 | 1.1.1  | [Compare](https://example.com/c/dev-master..1.1.1) |{$devNullLicense}
+| []8;;https://example.com/r/a/package-4\\a/package-4]8;;\\](https://example.com/r/a/package-4) | [31mRemoved[39m   | 0.1.1              | -      | [Compare](https://example.com/r/0.1.1)             |{$package4License}
+| a/no-link-2                                      | [31mRemoved[39m   | 0.1.1              | -      |                                                    |{$noLink2License}
+
+</details>
+
+
+OUTPUT;
+                }
+
+                return <<<OUTPUT
+<details>
+<summary>Prod Packages (6 packages)</summary>
+
+| Prod Packages                                    | Operation  | Base    | Target | Link                                          |{$prodLicenseHeader}
+|--------------------------------------------------|------------|---------|--------|-----------------------------------------------|{$prodLicenseSeparator}
+| [a/package-1](https://example.com/r/a/package-1) | [32mNew[39m        | -       | 1.0.0  | [Compare](https://example.com/r/1.0.0)        |{$prodNullLicense}
+| a/no-link-1                                      | [32mNew[39m        | -       | 1.0.0  |                                               |{$prodNullLicense}
+| [a/package-2](https://example.com/r/a/package-2) | [36mUpgraded[39m   | 1.0.0   | 1.2.0  | [Compare](https://example.com/c/1.0.0..1.2.0) |{$prodNullLicense}
+| [a/package-3](https://example.com/r/a/package-3) | [33mDowngraded[39m | 2.0.0   | 1.1.1  | [Compare](https://example.com/c/2.0.0..1.1.1) |{$prodNullLicense}
+| a/no-link-2                                      | [33mDowngraded[39m | 2.0.0   | 1.1.1  |                                               |{$prodNullLicense}
+| php                                              | [35mChanged[39m    | >=7.4.6 | ^8.0   |                                               |{$prodNullLicense}
+
+</details>
+
+<details>
+<summary>Dev Packages (3 packages)</summary>
+
+| Dev Packages                                     | Operation | Base               | Target | Link                                               |{$devLicenseHeader}
+|--------------------------------------------------|-----------|--------------------|--------|----------------------------------------------------|{$devLicenseSeparator}
+| [a/package-5](https://example.com/r/a/package-5) | [35mChanged[39m   | dev-master 1234567 | 1.1.1  | [Compare](https://example.com/c/dev-master..1.1.1) |{$devNullLicense}
+| [a/package-4](https://example.com/r/a/package-4) | [31mRemoved[39m   | 0.1.1              | -      | [Compare](https://example.com/r/0.1.1)             |{$package4License}
+| a/no-link-2                                      | [31mRemoved[39m   | 0.1.1              | -      |                                                    |{$noLink2License}
+
+</details>
+
+
+OUTPUT;
+            }
+
+            return <<<OUTPUT
+<details>
+<summary>Prod Packages (6 packages)</summary>
+
+| Prod Packages                                    | Operation  | Base    | Target | Link                                          |{$prodLicenseHeader}
+|--------------------------------------------------|------------|---------|--------|-----------------------------------------------|{$prodLicenseSeparator}
+| [a/package-1](https://example.com/r/a/package-1) | New        | -       | 1.0.0  | [Compare](https://example.com/r/1.0.0)        |{$prodNullLicense}
+| a/no-link-1                                      | New        | -       | 1.0.0  |                                               |{$prodNullLicense}
+| [a/package-2](https://example.com/r/a/package-2) | Upgraded   | 1.0.0   | 1.2.0  | [Compare](https://example.com/c/1.0.0..1.2.0) |{$prodNullLicense}
+| [a/package-3](https://example.com/r/a/package-3) | Downgraded | 2.0.0   | 1.1.1  | [Compare](https://example.com/c/2.0.0..1.1.1) |{$prodNullLicense}
+| a/no-link-2                                      | Downgraded | 2.0.0   | 1.1.1  |                                               |{$prodNullLicense}
+| php                                              | Changed    | >=7.4.6 | ^8.0   |                                               |{$prodNullLicense}
+
+</details>
+
+<details>
+<summary>Dev Packages (3 packages)</summary>
+
+| Dev Packages                                     | Operation | Base               | Target | Link                                               |{$devLicenseHeader}
+|--------------------------------------------------|-----------|--------------------|--------|----------------------------------------------------|{$devLicenseSeparator}
+| [a/package-5](https://example.com/r/a/package-5) | Changed   | dev-master 1234567 | 1.1.1  | [Compare](https://example.com/c/dev-master..1.1.1) |{$devNullLicense}
+| [a/package-4](https://example.com/r/a/package-4) | Removed   | 0.1.1              | -      | [Compare](https://example.com/r/0.1.1)             |{$package4License}
+| a/no-link-2                                      | Removed   | 0.1.1              | -      |                                                    |{$noLink2License}
+
+</details>
+
+
+OUTPUT;
+        }
+
+        if ($decorated) {
+            if ($this->supportsLinks()) {
+                return <<<OUTPUT
+<details>
+<summary>Prod Packages (6 packages)</summary>
+
+| Prod Packages | Operation  | Base    | Target |{$prodLicenseHeader}
+|---------------|------------|---------|--------|{$prodLicenseSeparator}
+| ]8;;https://example.com/r/a/package-1\a/package-1]8;;\   | [32mNew[39m        | -       | 1.0.0  |{$prodNullLicense}
+| a/no-link-1   | [32mNew[39m        | -       | 1.0.0  |{$prodNullLicense}
+| ]8;;https://example.com/r/a/package-2\a/package-2]8;;\   | [36mUpgraded[39m   | 1.0.0   | 1.2.0  |{$prodNullLicense}
+| ]8;;https://example.com/r/a/package-3\a/package-3]8;;\   | [33mDowngraded[39m | 2.0.0   | 1.1.1  |{$prodNullLicense}
+| a/no-link-2   | [33mDowngraded[39m | 2.0.0   | 1.1.1  |{$prodNullLicense}
+| php           | [35mChanged[39m    | >=7.4.6 | ^8.0   |{$prodNullLicense}
+
+</details>
+
+<details>
+<summary>Dev Packages (3 packages)</summary>
+
+| Dev Packages | Operation | Base               | Target |{$devLicenseHeader}
+|--------------|-----------|--------------------|--------|{$devLicenseSeparator}
+| ]8;;https://example.com/r/a/package-5\a/package-5]8;;\  | [35mChanged[39m   | dev-master 1234567 | 1.1.1  |{$devNullLicense}
+| ]8;;https://example.com/r/a/package-4\a/package-4]8;;\  | [31mRemoved[39m   | 0.1.1              | -      |{$package4License}
+| a/no-link-2  | [31mRemoved[39m   | 0.1.1              | -      |{$noLink2License}
+
+</details>
+
+
+OUTPUT;
+            }
+
+            return <<<OUTPUT
+<details>
+<summary>Prod Packages (6 packages)</summary>
+
+| Prod Packages | Operation  | Base    | Target |{$prodLicenseHeader}
+|---------------|------------|---------|--------|{$prodLicenseSeparator}
+| a/package-1   | [32mNew[39m        | -       | 1.0.0  |{$prodNullLicense}
+| a/no-link-1   | [32mNew[39m        | -       | 1.0.0  |{$prodNullLicense}
+| a/package-2   | [36mUpgraded[39m   | 1.0.0   | 1.2.0  |{$prodNullLicense}
+| a/package-3   | [33mDowngraded[39m | 2.0.0   | 1.1.1  |{$prodNullLicense}
+| a/no-link-2   | [33mDowngraded[39m | 2.0.0   | 1.1.1  |{$prodNullLicense}
+| php           | [35mChanged[39m    | >=7.4.6 | ^8.0   |{$prodNullLicense}
+
+</details>
+
+<details>
+<summary>Dev Packages (3 packages)</summary>
+
+| Dev Packages | Operation | Base               | Target |{$devLicenseHeader}
+|--------------|-----------|--------------------|--------|{$devLicenseSeparator}
+| a/package-5  | [35mChanged[39m   | dev-master 1234567 | 1.1.1  |{$devNullLicense}
+| a/package-4  | [31mRemoved[39m   | 0.1.1              | -      |{$package4License}
+| a/no-link-2  | [31mRemoved[39m   | 0.1.1              | -      |{$noLink2License}
+
+</details>
+
+
+OUTPUT;
+        }
+
+        return <<<OUTPUT
+<details>
+<summary>Prod Packages (6 packages)</summary>
+
+| Prod Packages | Operation  | Base    | Target |{$prodLicenseHeader}
+|---------------|------------|---------|--------|{$prodLicenseSeparator}
+| a/package-1   | New        | -       | 1.0.0  |{$prodNullLicense}
+| a/no-link-1   | New        | -       | 1.0.0  |{$prodNullLicense}
+| a/package-2   | Upgraded   | 1.0.0   | 1.2.0  |{$prodNullLicense}
+| a/package-3   | Downgraded | 2.0.0   | 1.1.1  |{$prodNullLicense}
+| a/no-link-2   | Downgraded | 2.0.0   | 1.1.1  |{$prodNullLicense}
+| php           | Changed    | >=7.4.6 | ^8.0   |{$prodNullLicense}
+
+</details>
+
+<details>
+<summary>Dev Packages (3 packages)</summary>
+
+| Dev Packages | Operation | Base               | Target |{$devLicenseHeader}
+|--------------|-----------|--------------------|--------|{$devLicenseSeparator}
+| a/package-5  | Changed   | dev-master 1234567 | 1.1.1  |{$devNullLicense}
+| a/package-4  | Removed   | 0.1.1              | -      |{$package4License}
+| a/no-link-2  | Removed   | 0.1.1              | -      |{$noLink2License}
+
+</details>
+
+
+OUTPUT;
+    }
+
+    protected function getFormatter(OutputInterface $output): Formatter
+    {
+        return new GithubPrFormatter($output);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `pr` output format (`--format=pr`) that wraps each section in GitHub-flavored `<details>/<summary>` blocks
- The summary line shows the section title and package count (e.g. `Prod Packages (6 packages)`)
- Extends `MarkdownTableFormatter` — same table rendering, just collapsible
- Registers the formatter as `pr` in `FormatterContainer`
- Updates `--format` option description and `--help` text
- Updates README with the new format and usage example

## Output example

```
<details>
<summary>Prod Packages (6 packages)</summary>

| Prod Packages | Operation  | Base  | Target |
|---------------|------------|-------|--------|
| vendor/pkg    | Upgraded   | 1.0.0 | 1.2.0  |
...

</details>
```

Closes #50