### PR TITLE
Add --allow-missing option to treat missing composer.lock as empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ composer diff --help # Display detailed usage instructions
  - `--gitlab-domains` - custom gitlab domains for compare/release URLs - default: use composer config
  - `--filter` - limit output to packages matching the given glob pattern (e.g. `symfony/*`); can be specified multiple times
  - `--sort` - sort packages alphabetically by name; use `--sort=operation` to group by operation type (installs, upgrades, downgrades, removals)
+ - `--allow-missing` - treat missing `composer.lock` files as empty (all target packages reported as new installs)
  
 ## Advanced usage
 
@@ -96,6 +97,7 @@ composer diff --filter="symfony/*" # Show only symfony packages
 composer diff --filter="symfony/*" --filter="doctrine/*" # Show symfony and doctrine packages
 composer diff --sort # Sort packages alphabetically by name
 composer diff --sort=operation # Group packages by operation type (installs, upgrades, downgrades, removals)
+composer diff HEAD:new-dir/composer.lock composer.lock --allow-missing # Compare against a lockfile that doesn't exist on the base ref
 ```
 
 You can find more documentation in the [docs](docs) directory.

--- a/src/Command/DiffCommand.php
+++ b/src/Command/DiffCommand.php
@@ -59,6 +59,7 @@ class DiffCommand extends BaseCommand
             ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Limit output to packages matching given glob pattern(s)', [])
             ->addOption('sort', null, InputOption::VALUE_OPTIONAL, 'Sort packages by "name" or "operation"', false)
             ->addOption('strict', 's', InputOption::VALUE_NONE, 'Return non-zero exit code if there are any changes')
+            ->addOption('allow-missing', null, InputOption::VALUE_NONE, 'Treat missing composer.lock files as empty (useful for new projects/directories)')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command displays all dependency changes between two <comment>composer.lock</comment> files.
 
@@ -155,13 +156,14 @@ EOF
         $prodOperations = new DiffEntries([]);
         $devOperations = new DiffEntries([]);
         $filters = $input->getOption('filter');
+        $allowMissingFiles = $input->getOption('allow-missing');
 
         if (!$input->getOption('no-prod')) {
-            $prodOperations = $this->packageDiff->getPackageDiff($base, $target, false, $withPlatform, $onlyDirect);
+            $prodOperations = $this->packageDiff->getPackageDiff($base, $target, false, $withPlatform, $onlyDirect, $allowMissingFiles);
         }
 
         if (!$input->getOption('no-dev')) {
-            $devOperations = $this->packageDiff->getPackageDiff($base, $target, true, $withPlatform, $onlyDirect);
+            $devOperations = $this->packageDiff->getPackageDiff($base, $target, true, $withPlatform, $onlyDirect, $allowMissingFiles);
         }
 
         if (!empty($filters)) {

--- a/src/PackageDiff.php
+++ b/src/PackageDiff.php
@@ -135,7 +135,7 @@ class PackageDiff
         return new ArrayRepository($packages);
     }
 
-    private function loadPackages(string $path, bool $dev, bool $withPlatform, bool $allowMissingFiles = false): ArrayRepository
+    private function loadPackages(string $path, bool $dev, bool $withPlatform, bool $allowMissingFiles): ArrayRepository
     {
         $data = \json_decode($this->getFileContents($path, true, $allowMissingFiles), true);
 

--- a/src/PackageDiff.php
+++ b/src/PackageDiff.php
@@ -100,11 +100,11 @@ class PackageDiff
         return $operations;
     }
 
-    public function getPackageDiff(string $from, string $to, bool $dev, bool $withPlatform, bool $onlyDirect = false): DiffEntries
+    public function getPackageDiff(string $from, string $to, bool $dev, bool $withPlatform, bool $onlyDirect = false, bool $allowMissingFiles = false): DiffEntries
     {
         return $this->getDiff(
-            $this->loadPackages($from, $dev, $withPlatform),
-            $this->loadPackages($to, $dev, $withPlatform),
+            $this->loadPackages($from, $dev, $withPlatform, $allowMissingFiles),
+            $this->loadPackages($to, $dev, $withPlatform, $allowMissingFiles),
             array_merge($this->getDirectPackages($from), $this->getDirectPackages($to)),
             $onlyDirect
         );
@@ -135,9 +135,9 @@ class PackageDiff
         return new ArrayRepository($packages);
     }
 
-    private function loadPackages(string $path, bool $dev, bool $withPlatform): ArrayRepository
+    private function loadPackages(string $path, bool $dev, bool $withPlatform, bool $allowMissingFiles = false): ArrayRepository
     {
-        $data = \json_decode($this->getFileContents($path), true);
+        $data = \json_decode($this->getFileContents($path, true, $allowMissingFiles), true);
 
         return $this->loadPackagesFromArray($data, $dev, $withPlatform);
     }
@@ -160,7 +160,7 @@ class PackageDiff
         return $packages; // @phpstan-ignore return.type
     }
 
-    private function getFileContents(string $path, bool $lockFile = true): string
+    private function getFileContents(string $path, bool $lockFile = true, bool $allowMissingFiles = false): string
     {
         $originalPath = $path;
 
@@ -192,12 +192,12 @@ class PackageDiff
         $outputString = implode("\n", $output);
 
         if (0 !== $exit) {
-            if ($lockFile) {
+            if ($lockFile && !$allowMissingFiles) {
                 throw new \RuntimeException(sprintf('Could not open file %s or find it in git as %s: %s', $originalPath, $path, $outputString));
             }
 
             /* @infection-ignore-all False-positive */
-            return '{}'; // Do not throw exception for composer.json as it might not exist and that's fine
+            return '{}';
         }
 
         return $outputString;

--- a/tests/Command/DiffCommandTest.php
+++ b/tests/Command/DiffCommandTest.php
@@ -140,6 +140,21 @@ class DiffCommandTest extends TestCase
         $this->assertStringNotContainsString('twig/twig', $output);
     }
 
+    public function testAllowMissingOption(): void
+    {
+        $diff = $this->getMockBuilder(PackageDiff::class)->getMock();
+        $command = new DiffCommand($diff);
+        $command->setApplication($this->getComposerApplication());
+        $tester = new CommandTester($command);
+
+        $diff->expects($this->atLeast(1))
+            ->method('getPackageDiff')
+            ->with($this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything(), true)
+            ->willReturn($this->getEntries([], $this->getGenerators()));
+
+        $this->assertSame(0, $tester->execute(['--allow-missing' => true]));
+    }
+
     public function testExtraGitlabDomains(): void
     {
         $diff = $this->getMockBuilder(PackageDiff::class)->getMock();

--- a/tests/PackageDiffTest.php
+++ b/tests/PackageDiffTest.php
@@ -162,7 +162,7 @@ class PackageDiffTest extends TestCase
         foreach ($operations as $entry) {
             $this->assertTrue($entry->isInstall(), 'All entries should be installs when base is missing');
         }
-        $this->assertNotEmpty($operations);
+        $this->assertNotCount(0, $operations);
     }
 
     public function testMissingGitRefAllowed(): void
@@ -174,7 +174,7 @@ class PackageDiffTest extends TestCase
         foreach ($operations as $entry) {
             $this->assertTrue($entry->isInstall(), 'All entries should be installs when base ref is missing');
         }
-        $this->assertNotEmpty($operations);
+        $this->assertNotCount(0, $operations);
     }
 
     public function testLoadFromEmptyArray(): void

--- a/tests/PackageDiffTest.php
+++ b/tests/PackageDiffTest.php
@@ -147,6 +147,36 @@ class PackageDiffTest extends TestCase
         $diff->getPackageDiff('invalid-ref', '', true, true);
     }
 
+    public function testMissingLocalFileThrowsByDefault(): void
+    {
+        $diff = new PackageDiff();
+        $this->expectException(\RuntimeException::class);
+        $diff->getPackageDiff(__DIR__.'/fixtures/nonexistent/composer.lock', __DIR__.'/fixtures/target/composer.lock', false, false);
+    }
+
+    public function testMissingLocalFileAllowed(): void
+    {
+        $diff = new PackageDiff();
+        $operations = $diff->getPackageDiff(__DIR__.'/fixtures/nonexistent/composer.lock', __DIR__.'/fixtures/target/composer.lock', false, false, false, true);
+
+        foreach ($operations as $entry) {
+            $this->assertTrue($entry->isInstall(), 'All entries should be installs when base is missing');
+        }
+        $this->assertNotEmpty($operations);
+    }
+
+    public function testMissingGitRefAllowed(): void
+    {
+        $diff = new PackageDiff();
+        $this->prepareGit();
+        $operations = $diff->getPackageDiff('HEAD:nonexistent/composer.lock', '', false, false, false, true);
+
+        foreach ($operations as $entry) {
+            $this->assertTrue($entry->isInstall(), 'All entries should be installs when base ref is missing');
+        }
+        $this->assertNotEmpty($operations);
+    }
+
     public function testLoadFromEmptyArray(): void
     {
         $diff = new PackageDiff();


### PR DESCRIPTION
## Summary

- Adds `--allow-missing` flag that treats a missing `composer.lock` (local path or git ref) as an empty lockfile, reporting all target packages as new installs instead of throwing an error
- Passes the flag through the call chain (`getPackageDiff` → `loadPackages` → `getFileContents`) rather than using mutable state on `PackageDiff`
- Covers both local file paths and git ref paths

## Motivation

When using [composer-bin](https://github.com/bamarni/composer-bin-plugin) or similar setups where a new tool directory is introduced on a branch, there is no corresponding `composer.lock` on the base branch yet. Running `composer diff` against a non-existing lockfile currently throws an error, making it impossible to review the newly added dependencies.

## Usage

```shell
composer diff HEAD:new-dir/composer.lock composer.lock --allow-missing
composer diff /path/to/new/project/composer.lock composer.lock --allow-missing
```

Closes #46